### PR TITLE
Simple forwardAuth concept (#69)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,5 @@ jobs:
             docker-compose.yml
             docker-compose.test.yml
           compose-flags: "-p serve-test --profile cpu"
-          up-flags: "--build --abort-on-container-exit --exit-code-from backend-cpu"
+          up-flags: "--build --abort-on-container-exit --exit-code-from tester"
           down-flags: "--volumes"

--- a/Makefile
+++ b/Makefile
@@ -153,13 +153,13 @@ test:					## Run tests.
 		--profile cpu \
 		-f docker-compose.yml \
 		-f docker-compose.test.yml up --build \
-		--abort-on-container-exit --exit-code-from backend-cpu; \
+		--abort-on-container-exit --exit-code-from tester; \
 	else \
 		docker compose -p serve-test \
 		--profile gpu \
 		-f docker-compose.yml \
 		-f docker-compose.test.yml up --build \
-		--abort-on-container-exit --exit-code-from backend; fi
+		--abort-on-container-exit --exit-code-from tester; fi
 	@echo "Tearing everything down..."
 	@docker compose -p serve-test \
 		--profile $(PROFILE) \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,8 +5,7 @@ x-override: &override
   volumes:
     - configs:/var/serve/configs
     - models:/var/serve/models
-  command: test
-  tty: true
+  command: webserver
 
 volumes:
   configs:
@@ -32,3 +31,24 @@ services:
 
   database:
       container_name: serve-database_test
+
+  # Same image as the backend, but with a different command
+  # Runs the tests inside the container, calling the backend
+  tester:
+    image: ghcr.io/links-ads/serve-backend:${PROJECT_VERSION:-latest}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - configs:/var/serve/configs
+      - models:/var/serve/models
+    env_file:
+      - .env
+    environment:
+      - RUN_MIGRATIONS=false  # assume backend runs them 
+    depends_on:
+      database:
+        condition: service_healthy
+      traefik:
+        condition: service_healthy
+    container_name: serve-tester_test
+    command: test
+    tty: true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,6 +32,26 @@ run_tests() {
         # run alembic upgrade head, exit only if it fails
         alembic upgrade head || exit 1
     fi
+    echo "Waiting for the backend to start..."
+    
+    # Set timeout (in seconds)
+    timeout=60
+    start_time=$(date +%s)
+    while true; do
+        # Try to connect to the backend
+        if curl -s "http://${BACKEND_HOST}:${BACKEND_PORT}" > /dev/null; then
+            echo "Backend is up!"
+            break
+        fi
+        # Check if we've exceeded the timeout
+        current_time=$(date +%s)
+        if [ $((current_time - start_time)) -ge $timeout ]; then
+            echo "Timeout waiting for backend to start. Exiting."
+            exit 1
+        fi
+        echo "Backend not ready yet. Retrying in 5 seconds..."
+        sleep 5
+    done
     echo "Running pytest..."
     exec pytest -sv --cov-report=term --log-cli-level=${LOG_LEVEL:-info} --cov=src tests/
 }

--- a/src/triton_serve/api/models/__init__.py
+++ b/src/triton_serve/api/models/__init__.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/models")
 
 
 @router.get(
-    "/",
+    "",
     response_model=list[ModelSchema],
     status_code=200,
     tags=["models"],
@@ -84,7 +84,7 @@ def get_model(
 
 
 @router.post(
-    "/",
+    "",
     status_code=201,
     response_model=list[ModelSchema],
     tags=["models"],

--- a/src/triton_serve/api/services/__init__.py
+++ b/src/triton_serve/api/services/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from docker import DockerClient
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from triton_serve.api.dto import ServiceCreateBody
@@ -161,7 +161,11 @@ def delete_service(
     )
 
 
-@router.post("/services/{service_id}/stop", status_code=200, tags=["services"], response_model=ServiceSchema)
+@router.post(
+    "/services/{service_id}/stop",
+    status_code=204,
+    tags=["services"],
+)
 def stop_service(
     service_id: int,
     docker: DockerClient = Depends(docker_client),
@@ -176,7 +180,7 @@ def stop_service(
     **Returns:**
     - `None`
     """
-    return domain.stop_service(
+    domain.stop_service(
         db=db,
         client=docker,
         service_id=service_id,
@@ -184,12 +188,12 @@ def stop_service(
 
 
 @router.get(
-    "/status",
+    "/status/{service_name}",
     status_code=200,
     tags=["status"],
 )
 def check_service_status(
-    request: Request,
+    service_name: str,
     db: Session = Depends(get_db),
     docker: DockerClient = Depends(docker_client),
     _: Any = Depends(require_service),
@@ -202,4 +206,30 @@ def check_service_status(
     - `202` if the service is starting,
     - `503` if the service is cannot be started.
     """
-    pass
+    print(f"Checking status of service: {service_name}")
+    service = domain.get_service_by_name(
+        db=db,
+        service_name=service_name,
+        docker_client=docker,
+    )
+    match service.container_status:
+        case ServiceStatus.ACTIVE:
+            print(f"Service '{service_name}' is active")
+            domain.update_active_time(db=db, service=service)
+            return 200
+        case ServiceStatus.STARTING:
+            print(f"Service '{service_name}' is starting")
+            domain.update_active_time(db=db, service=service)
+            return 202
+        case ServiceStatus.STOPPED:
+            print(f"Service '{service_name}' is stopped")
+            domain.start_service(
+                db=db,
+                client=docker,
+                service=service,
+            )
+            return 202
+        case ServiceStatus.ERROR:
+            raise HTTPException(status_code=503, detail=f"Service '{service_name}' is in error state")
+        case _:
+            raise HTTPException(status_code=503, detail=f"Service '{service_name}' is unavailable")

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -65,6 +65,32 @@ def get_service(db: Session, service_id: int, docker_client: DockerClient | None
     return service
 
 
+def get_service_by_name(db: Session, service_name: str, docker_client: DockerClient | None = None):
+    """Returns a specific service by name, if present.
+
+    Args:
+        db (Session): The database session.
+        service_name (str): The name of the service.
+
+    Returns:
+        Service: The requested service.
+    """
+    # get any service with the specified name, not deleted
+    service = (
+        db.query(Service)
+        .filter(
+            Service.service_name == service_name,
+            Service.deleted_at.is_(None),
+        )
+        .first()
+    )
+    if service is None:
+        raise HTTPException(status_code=404, detail=f"No active service named '{service_name}'")
+    if docker_client is not None:
+        return check_service_status(db=db, docker_client=docker_client, service=service)
+    return service
+
+
 def get_available_devices(db: Session, count: int, required_percentage: float = 100.0) -> list[Device]:
     """
     Returns a list of available devices, considering the allocation percentage.
@@ -528,20 +554,49 @@ def delete_service(
         raise HTTPException(status_code=500, detail=f"Unexpected error deleting service: {str(e)}")
 
 
+def start_service(
+    db: Session,
+    client: DockerClient,
+    service: Service,
+) -> None:
+    try:
+        LOG.debug(f"Starting service {service.service_id}...")
+        client.containers.get(service.container_id).start()
+        service.container_status = ServiceStatus.ACTIVE
+        service.last_active_time = datetime.now(tz=timezone.utc)
+        db.commit()
+    except NotFound:
+        raise HTTPException(status_code=404, detail="Service not found")
+    except Exception as e:
+        db.rollback()
+        LOG.debug(f"Error starting container: {str(e)}")
+        raise HTTPException(status_code=503, detail="Error restarting service")
+
+
+def update_active_time(db: Session, service: Service):
+    """Updates the last active time of a service.
+
+    Args:
+        db (Session): The database session.
+        service (Service): The service to update.
+    """
+    service.last_active_time = datetime.now(tz=timezone.utc)
+    db.commit()
+
+
 def stop_service(
     db: Session,
     client: DockerClient,
     service_id: int,
-) -> Service:
+) -> None:
     try:
+        LOG.debug(f"Stopping service {service_id}...")
         service = get_service(db=db, docker_client=client, service_id=service_id)
         client.containers.get(service.container_id).stop()
         service.container_status = ServiceStatus.STOPPED
         db.commit()
-        db.refresh(service)
-        return service
     except NotFound:
-        raise HTTPException(status_code=404, detail="Container not found")
+        raise HTTPException(status_code=404, detail="Service not found")
     except Exception as e:
         db.rollback()
-        raise HTTPException(status_code=500, detail=f"Error stopping container: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error stopping service: {str(e)}")

--- a/src/triton_serve/config/traefik.py
+++ b/src/triton_serve/config/traefik.py
@@ -42,15 +42,23 @@ class TraefikConfigManager:
             "http": {
                 "services": {service_name: {"loadBalancer": {"servers": [{"url": service_url}]}}},
                 "middlewares": {
-                    f"{service_name}_stripprefix": {"stripPrefix": {"prefixes": [prefix_name]}},
-                    f"{service_name}_auth": {
+                    f"{service_name}-stripprefix": {
+                        "stripPrefix": {"prefixes": [prefix_name]},
+                    },
+                    f"{service_name}-auth": {
                         "plugin": {
                             "traefik-api-key-middleware": {
                                 "authenticationHeader": True,
                                 "authenticationheaderName": "X-API-Key",
+                                "removeHeadersOnSuccess": False,
                                 "keys": api_keys,
                             }
                         }
+                    },
+                    f"{service_name}-forward": {
+                        "forwardAuth": {
+                            "address": f"http://backend:5000/status/{service_name}",
+                        },
                     },
                 },
                 "routers": {
@@ -58,8 +66,9 @@ class TraefikConfigManager:
                         "rule": path_prefix,
                         "entryPoints": ["http"],
                         "middlewares": [
-                            f"{service_name}_auth@file",
-                            f"{service_name}_stripprefix@file",
+                            f"{service_name}-auth@file",  # we first check that the key is associated with the service
+                            f"{service_name}-forward@file",  # then we check that the service is running (if it is stopped, we start it)
+                            f"{service_name}-stripprefix@file",  # we strip the prefix from the request
                         ],
                         "service": service_name,
                     }
@@ -88,7 +97,7 @@ class TraefikConfigManager:
         with open(yaml_file_name) as file:
             config = yaml.safe_load(file)
 
-        auth_middleware = config["http"]["middlewares"][f"{service_name}_auth"]["plugin"]["traefik-api-key-middleware"]
+        auth_middleware = config["http"]["middlewares"][f"{service_name}-auth"]["plugin"]["traefik-api-key-middleware"]
         if key not in auth_middleware["keys"]:
             auth_middleware["keys"].append(key)
 
@@ -113,7 +122,7 @@ class TraefikConfigManager:
         with open(yaml_file_name) as file:
             config = yaml.safe_load(file)
 
-        auth_middleware = config["http"]["middlewares"][f"{service_name}_auth"]["plugin"]["traefik-api-key-middleware"]
+        auth_middleware = config["http"]["middlewares"][f"{service_name}-auth"]["plugin"]["traefik-api-key-middleware"]
         if key in auth_middleware["keys"]:
             auth_middleware["keys"].remove(key)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,10 @@ import docker
 import multipart
 import pytest
 import urllib3
-from fastapi.testclient import TestClient
+from httpx import Client
 
 from triton_serve.config import get_settings
-from triton_serve.extensions import get_db
-from triton_serve.factory import create_app
+from triton_serve.database import database_manager
 
 logging.getLogger(multipart.__name__).setLevel(logging.WARNING)
 logging.getLogger(docker.__name__).setLevel(logging.WARNING)
@@ -34,18 +33,6 @@ def test_repository():
     yield TEST_GIT_REPO
 
 
-@pytest.fixture(scope="function")
-def test_db():
-    """
-    Get the database connection
-
-    :return: the database connection
-
-    """
-    db = next(get_db())
-    yield db
-
-
 @pytest.fixture(scope="session")
 def test_settings():
     """
@@ -56,26 +43,38 @@ def test_settings():
 
 
 @pytest.fixture(scope="session")
-def test_app():
+def test_connection(test_settings):
     """
-    Get the uvicorn test app
+    Get the database connection
 
-    :return: the test app
+    :return: the database connection
+
     """
-    LOG.info("Initializing webserver...")
-    app = create_app(settings=get_settings())
-    yield app
+    database_manager.init(test_settings.database_url)
+    yield
+    database_manager.close()
 
 
 @pytest.fixture(scope="session")
-def test_client(test_app, test_settings):
+def test_db(test_connection):
     """
-    Get the test client to call the endpoints of the webserver
+    Get the database session
+
+    :return: the database session
     """
+    with database_manager.session() as session:
+        yield session
+
+
+@pytest.fixture(scope="session")
+def test_client(test_settings, custom_headers=None, timeout=60):
     LOG.debug("Initializing test client...")
-    client = TestClient(app=test_app)
+    client = Client(base_url=f"http://{test_settings.backend_host}:{test_settings.backend_port}", timeout=timeout)
     client.headers.update({"X-API-Key": test_settings.api_keys[0]})
+    if custom_headers:
+        client.headers.update(custom_headers)
     yield client
+    client.close()
 
 
 @pytest.fixture(scope="session")
@@ -97,7 +96,7 @@ def test_docker():
 
 
 @pytest.fixture(scope="session")
-def make_zip():
+def make_zip() -> io.BytesIO:
     @contextmanager
     def _create_zip(
         archive_name: str = "repository.zip",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -28,7 +28,7 @@ def create_api_key(test_db):
     return _create_api_key
 
 
-@pytest.mark.order(after="test_models.py::test_get_model_wrong_params")
+@pytest.mark.order(after="test_models.py::test_create_models_from_zip")
 def test_api_key_authorized(test_client, test_settings):
     # make a get request for /models and set the X-API-Key header to the app_secret
     response = test_client.get("/models", headers={"X-API-Key": test_settings.api_keys[0]})
@@ -159,11 +159,13 @@ def test_add_service_to_key(
             "resources": {"gpus": 0, "shm_size": 256, "mem_size": 4096},
         },
     )
+    LOG.debug("Service response: %s", service_response.text)
     assert service_response.status_code == 201
     service_id = service_response.json()["service_id"]
 
     # Add service to key
     response = test_client.post(f"/keys/{api_key.key_id}/services/{service_id}")
+    LOG.debug("Add service response: %s", response.text)
     assert response.status_code == 200
     data = response.json()
     assert len(data["services"]) == 1
@@ -177,28 +179,41 @@ def test_add_service_to_key(
 def test_check_service_status(test_client):
     # using the client, get the service key associated with test project
     response = test_client.get("/keys", params={"project": "status_check"})
+    LOG.debug("Response: %s", response.text)
     assert response.status_code == 200
     data = response.json()
     assert len(data) > 0
     key = data[0]["value"]
 
     # Test with user key
-    response = test_client.get("/status", headers={"X-API-Key": "test_key_userkey1"})
+    response = test_client.get(
+        "/status/trt-srv_test_another_test_service",
+        headers={"X-API-Key": "test_key_userkey1"},
+    )
     LOG.debug(response.text)
     assert response.status_code == 403
 
     # Test with no key
-    response = test_client.get("/status", headers={"X-API-Key": ""})
+    response = test_client.get(
+        "/status/trt-srv_test_another_test_service",
+        headers={"X-API-Key": ""},
+    )
     LOG.debug(response.text)
     assert response.status_code == 403
 
     # Test with invalid key
-    response = test_client.get("/status", headers={"X-API-Key": "invalid_key"})
+    response = test_client.get(
+        "/status/trt-srv_test_another_test_service",
+        headers={"X-API-Key": "invalid_key"},
+    )
     LOG.debug(response.text)
     assert response.status_code == 401
 
     # test with the service key
-    response = test_client.get("/status", headers={"X-API-Key": key})
+    response = test_client.get(
+        "/status/trt-srv_test_another_test_service",
+        headers={"X-API-Key": key},
+    )
     LOG.debug(response.text)
     assert response.status_code == 200
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,7 @@
+import io
 import logging
 import os
+from typing import cast
 
 import pytest
 
@@ -25,7 +27,7 @@ def test_create_models_from_zip_wrong_content(test_client, make_zip, model):
     """
     with make_zip(include_models=[model]) as src:
         response = test_client.post("/models", files={"package": src})
-    LOG.debug(f"Response: {response.json()}")
+    LOG.debug(f"Response: {response.text}")
     assert response.status_code == 422
 
 
@@ -36,8 +38,9 @@ def test_create_models_from_zip(test_client, test_settings, make_zip, model):
     Test with successful model creation using both onnx and config and only the onnx file.
     """
     with make_zip(include_models=[model]) as src:
+        src = cast(io.BytesIO, src)
         response = test_client.post("/models", files={"package": src})
-    LOG.debug(f"Response: {response.json()}")
+    LOG.debug(f"Response: {response.text}")
     assert response.status_code == 201
     # check if the model is present inside the models repository
     expected_model_root = test_settings.repository_path / model
@@ -58,7 +61,7 @@ def test_create_models_from_zip(test_client, test_settings, make_zip, model):
 def test_create_models_from_zip_already_existing(test_client, make_zip, model):
     with make_zip(include_models=[model]) as package:
         response = test_client.post("/models", files={"package": package})
-    LOG.debug(f"Response: {response.json()}")
+    LOG.debug(f"Response: {response.text}")
     assert response.status_code == 409
 
 
@@ -67,7 +70,7 @@ def test_create_models_from_zip_already_existing(test_client, make_zip, model):
 def test_create_models_from_zip_already_existing_with_update(test_client, test_settings, make_zip, model):
     with make_zip(include_models=[model]) as package:
         response = test_client.post("/models", data={"update": True}, files={"package": package})
-    LOG.debug(f"Response: {response.json()}")
+    LOG.debug(f"Response: {response.text}")
     assert response.status_code == 201
     # check if the model is present inside the models repository
     expected_model_root = test_settings.repository_path / model
@@ -89,7 +92,7 @@ def test_create_models_from_repo(test_client, test_settings, test_repository):
     model_dirs = {d for d in repository_root.iterdir() if d.is_dir()}
 
     response = test_client.post("/models/repository", params={"repository_url": test_repository})
-    LOG.debug(f"Response: {response.json()}")
+    LOG.debug(f"Response: {response.text}")
     assert response.status_code == 201
 
     updated_model_dirs = {d for d in repository_root.iterdir() if d.is_dir()}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -106,6 +106,39 @@ def test_stop_service(
 
 
 @pytest.mark.order(after="test_stop_service")
+def test_restart_services(test_docker, test_settings, test_client):
+    # make sure it does not work without auth
+    response = requests.get("http://traefik/trt-srv_test_svc4/v2/health/ready")
+    LOG.debug(f"response: {response.text}")
+    assert response.status_code == 403
+    # make sure it returns a 404 for a non-existent service
+    headers = {"X-API-Key": test_settings.api_keys[0]}
+    response = requests.get(
+        "http://traefik/whatever/v2/health/ready",
+        headers=headers,
+    )
+    LOG.debug(f"response: {response.text}")
+    assert response.status_code == 404
+    # we need to 'manually' restart the service since there's no backed running
+    test_client.get("status/trt-srv_test_svc4")
+    # attempt a couple of times to get a response != 50x using traefik
+    for _ in range(3):
+        response = requests.get(
+            "http://traefik/trt-srv_test_svc4/v2/health/ready",
+            headers=headers,
+        )
+        LOG.debug(f"headers: {response.headers}")
+        LOG.debug(f"response: {response.text}")
+        if response.status_code not in (502, 503):
+            break
+        time.sleep(5)
+
+    assert response.status_code == 200
+    container = test_docker.containers.get("trt-srv_test_svc4")
+    assert container.status == "running"
+
+
+@pytest.mark.order(after="test_check_service_status")
 @pytest.mark.parametrize("name", ["trt-srv_test_svc2", "trt-srv_test_svc3"])
 def test_triton_ping_unathorized(name):
     url = f"http://traefik/{name}/v2/health/ready"


### PR DESCRIPTION
- add forwardAuth endpoint with service name
- add simple request-based container restart
- refactor tests to use an actual backend to verify the new endpoint
- update GH workflow to reflect changes