### PR TITLE
fix(sentinel): use purge_message_schedule for queue purge beat task

### DIFF
--- a/src/triton_serve/tasks.py
+++ b/src/triton_serve/tasks.py
@@ -29,7 +29,7 @@ def setup_periodic_tasks(sender, **_):
     )
 
     sender.add_periodic_task(
-        settings.queue_messages_purging_interval,  # type: ignore
+        settings.purge_message_schedule,
         purge_queue_messages.s(),  # type: ignore
         name="Purge queue messages",
     )


### PR DESCRIPTION
## Summary

`setup_periodic_tasks` (Celery beat) referenced `settings.queue_messages_purging_interval`, which does not exist on `AppSettings`. Accessing the missing attribute raised `AttributeError` at beat configure time, so the `purge_queue_messages` periodic task never registered (and beat logged a noisy error). The earlier-registered `update_service_status` task still scheduled, so the #120 background reconcile was unaffected.

The real field is `purge_message_schedule` (`config/schema.py`, default `86400`).

## Change

- `src/triton_serve/tasks.py`: `settings.queue_messages_purging_interval` → `settings.purge_message_schedule` (one line; dropped the now-unneeded `# type: ignore` since the attribute genuinely exists).

## Testing

- `make test PROFILE=cpu` → 97 passed, 1 skipped, 0 failed (matches clean baseline). The beat handler now registers both periodic tasks without raising.