### PR TITLE
fix(services): stop sentinel reviving deleted and terminal services

### DIFF
--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -79,7 +79,7 @@ def list_services(
     Returns:
         list[Service]: The list of services.
     """
-    statement = db.query(Service)
+    statement = db.query(Service).filter(Service.deleted_at.is_(None))
     if names:
         statement = statement.filter(Service.service_name.in_(names))
     if statuses:
@@ -264,11 +264,14 @@ def check_service_status(db: Session, docker_client: DockerClient, service: Serv
         db.refresh(service)
         return service
     except NotFound, NullResource:
-        # the container object is gone; record it as MISSING (recoverable) without
-        # touching deleted_at — deletion is a user-only action.
-        service.container_status = ServiceStatus.MISSING
-        db.commit()
-        db.refresh(service)
+        # the container object is gone. only a previously-running service can go MISSING:
+        # transitioning from a terminal/managed state (ERROR, STOPPED) would let the sentinel
+        # revive services the user stopped or that already exhausted their restart budget.
+        # deleted_at is left untouched — deletion is a user-only action.
+        if service.container_status in (ServiceStatus.ACTIVE, ServiceStatus.STARTING):
+            service.container_status = ServiceStatus.MISSING
+            db.commit()
+            db.refresh(service)
         return service
     except APIError as e:
         service.container_status = ServiceStatus.ERROR

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -511,6 +511,59 @@ def test_sentinel_reconciles_missing(test_client, test_docker, test_db):
     assert service.container_id != old_container_id
 
 
+@pytest.mark.order(after="test_sentinel_reconciles_missing")
+def test_check_status_preserves_terminal_states(test_client, test_docker, test_db):
+    """A vanished container must not drag a terminal ERROR/STOPPED service into MISSING."""
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
+    service_id = service.service_id
+    original_status = service.container_status
+
+    # remove the container out-of-band so the daemon reports it gone
+    try:
+        test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
+    except NotFound:
+        pass
+
+    # an observational read finds the container gone but must leave a terminal state intact:
+    # only a previously-running service (ACTIVE/STARTING) may transition to MISSING
+    for terminal in (ServiceStatus.ERROR, ServiceStatus.STOPPED):
+        service.container_status = terminal
+        test_db.commit()
+        data = test_client.get(f"/services/{service_id}").json()
+        assert data["container_status"] == terminal.value
+
+    # restore for downstream tests
+    service.container_status = original_status
+    test_db.commit()
+    test_client.post(f"/services/{service_id}/refresh", params={"force_recreate": True})
+
+
+@pytest.mark.order(after="test_check_status_preserves_terminal_states")
+def test_deleted_service_excluded_from_listing(test_client, test_docker, test_db):
+    """Soft-deleted services must not appear in GET /services nor be revived by the sentinel."""
+    from datetime import datetime, timezone
+
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
+    service_id = service.service_id
+    original_deleted = service.deleted_at
+
+    # soft-delete the row (leave the container alone) and mark it MISSING as the daemon would
+    service.deleted_at = datetime.now(tz=timezone.utc)
+    service.container_status = ServiceStatus.MISSING
+    test_db.commit()
+
+    listing = test_client.get("/services").json()
+    assert all(s["service_id"] != service_id for s in listing)
+
+    # the sentinel polls the same listing, so a deleted service is never reconciled
+    update_service_status.apply(kwargs={"client": test_client})
+    test_db.refresh(service)
+    assert service.container_status == ServiceStatus.MISSING
+
+    service.deleted_at = original_deleted
+    test_db.commit()
+
+
 @pytest.mark.order(after="test_update_service_recreate")
 def test_delete_services(test_client, test_docker, test_db):
     # get all services


### PR DESCRIPTION
Closes #123 (the two stop-the-bleeding fixes; the structural reconcile-by-name and data cleanup remain as follow-ups).

### Context
Confirmed against production: of 43 service rows, 38 are soft-deleted and **30 of the 31 `MISSING` rows are deleted services** the sentinel was reviving every poll, storming `409` container-name conflicts and re-marking services `ERROR`.

### Changes
1. **`list_services` filters `deleted_at`** — it was the only service query returning soft-deleted rows. The sentinel polls `GET /services`, so deleted services were status-checked, marked `MISSING`, and reconciled — recreating containers the user deleted. This removes ~30/31 of the churn.
2. **`check_service_status` only transitions to `MISSING` from `ACTIVE`/`STARTING`** — the not-found branch previously set `MISSING` unconditionally, dragging terminal `ERROR` (and user-`STOPPED`) services back into the reconcile loop forever (the "exhausted restart budget, marking ERROR" spam). A container can only go missing from a previously-running state.

### Tests
- `test_check_status_preserves_terminal_states` — a vanished container leaves `ERROR`/`STOPPED` untouched.
- `test_deleted_service_excluded_from_listing` — soft-deleted services are absent from `GET /services` and the sentinel does not revive them.
- Full CPU suite on odin: **99 passed, 1 skipped** (was 97+1; +2 new).

### Not in this PR (follow-ups)
- Reconcile by name rather than stale `container_id` (teardown + self-heal guard) — the structural fix for genuinely-live MISSING services colliding with a stale same-named container. Partly an ops artifact (host power loss leaves docker "dirty").
- Running-only name precheck (`containers.list()`).
- Prune duplicate deleted rows in the DB.
