### PR TITLE
fix(services): reconcile by container name, not stale id

### DIFF
--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -613,8 +613,9 @@ def delete_service(
     service_id: int,
 ) -> Service:
     """
-    Deletes a triton docker container and the traefik config for the service.
-    Marks the service as deleted, deallocates associated devices, and removes the Docker container.
+    Soft-deletes a service: removes its Docker container and Traefik config and stamps deleted_at.
+    Device allocations are retained on the row but ignored while deleted (the allocator filters
+    out deleted services), so capacity is effectively released without dropping the records.
 
     Args:
         db (Session): The database session.

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from docker import DockerClient
 from docker.errors import APIError, ImageNotFound, NotFound, NullResource
+from docker.models.containers import Container
 from docker.models.images import Image
 from docker.types import DeviceRequest
 from fastapi import HTTPException
@@ -28,6 +29,19 @@ from triton_serve.database.model import (
 )
 
 LOG = logging.getLogger("uvicorn")
+
+
+def get_container_by_name(client: DockerClient, name: str) -> Container | None:
+    """Returns the container currently holding `name` (in any state), or None if absent.
+
+    Lookup is by name rather than id: a MISSING service's stored container_id is exactly what
+    no longer resolves, while a container under the service name may still exist (e.g. it came
+    back under a new id after a host reboot, or a stale one is squatting the name).
+    """
+    try:
+        return client.containers.get(name)
+    except NotFound:
+        return None
 
 
 def rebuild_service_config(
@@ -312,7 +326,7 @@ def spawn_service_container(
         HTTPException: If the container could not be created.
     """
     # check if container with the same name already exists
-    if worker_name in [container.name for container in client.containers.list()]:
+    if worker_name in [container.name for container in client.containers.list(all=True)]:
         raise HTTPException(status_code=409, detail=f"Container with name {worker_name} already exists")
 
     # prepare the requirements, if any
@@ -735,6 +749,11 @@ def recreate_service_container(
                 pass
             service.container_id = None  # type: ignore
 
+        # a stale/foreign container may still hold the name under a different id (e.g. dirty
+        # docker after a host reboot); clear it by name so the spawn below cannot 409.
+        if (squatter := get_container_by_name(client, service.service_name)) is not None:
+            squatter.remove(force=True)
+
         image = get_service_image(client, service.service_image)
         res = service.resources
         device_objs = [alloc.device for alloc in service.device_allocations]
@@ -802,13 +821,15 @@ def reconcile_missing_container(
             LOG.debug("Reconciliation already in progress for service %s, skipping", service.service_id)
             return
         try:
-            # lost-race / self-heal guard: if the container is back, just reconcile status
-            try:
-                client.containers.get(service.container_id)
+            # self-heal guard: a container under this service's name may already be up. it can
+            # come back under a NEW id (host reboot), so look it up by name, not the stale id.
+            # adopt a running one and just reconcile status; a dead one is cleared on recreate.
+            existing = get_container_by_name(client, service.service_name)
+            if existing is not None and existing.status == "running":
+                if service.container_id != existing.id:
+                    service.container_id = existing.id  # type: ignore
                 check_service_status(db=db, docker_client=client, service=service)
                 return
-            except NotFound, NullResource:
-                pass
 
             now = datetime.now(tz=timezone.utc)
             if (

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -562,6 +562,8 @@ def test_deleted_service_excluded_from_listing(test_client, test_docker, test_db
 
     service.deleted_at = original_deleted
     test_db.commit()
+
+
 @pytest.mark.order(after="test_deleted_service_excluded_from_listing")
 def test_reconcile_adopts_returned_container(test_docker, test_db, test_settings):
     """Reconcile adopts a container that is back under the service name (new id), without respawning."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -562,6 +562,80 @@ def test_deleted_service_excluded_from_listing(test_client, test_docker, test_db
 
     service.deleted_at = original_deleted
     test_db.commit()
+@pytest.mark.order(after="test_deleted_service_excluded_from_listing")
+def test_reconcile_adopts_returned_container(test_docker, test_db, test_settings):
+    """Reconcile adopts a container that is back under the service name (new id), without respawning."""
+    from triton_serve.api.services import domain
+
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
+    name = service.service_name
+    real = test_docker.containers.get(name)
+    for _ in range(10):
+        real.reload()
+        if real.status == "running":
+            break
+        time.sleep(1)
+    assert real.status == "running"
+
+    # lose track of the id: MISSING with a stale container_id while the container is genuinely up
+    service.container_status = ServiceStatus.MISSING
+    service.container_id = "stale-id-0000"
+    service.restart_attempts = 0
+    service.last_attempt_at = None
+    test_db.commit()
+
+    domain.reconcile_missing_container(
+        db=test_db,
+        client=test_docker,
+        service=service,
+        service_network=test_settings.service_network,
+        service_models_volume=test_settings.service_volume,
+        max_restart_attempts=test_settings.service_max_restart_attempts,
+        restart_cooldown=test_settings.service_restart_cooldown,
+    )
+
+    test_db.refresh(service)
+    assert service.container_id == real.id  # adopted the existing container
+    assert service.container_status != ServiceStatus.MISSING
+    assert len([c for c in test_docker.containers.list(all=True) if c.name == name]) == 1
+
+
+@pytest.mark.order(after="test_reconcile_adopts_returned_container")
+def test_reconcile_clears_name_squatter(test_docker, test_db, test_settings):
+    """A stale/foreign container holding the name is removed so recreate doesn't 409."""
+    from triton_serve.api.services import domain
+
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
+    name = service.service_name
+    image = service.service_image
+
+    # tear down the real container and leave a foreign one squatting the name under a different id
+    try:
+        test_docker.containers.get(name).remove(force=True)
+    except NotFound:
+        pass
+    squatter = test_docker.containers.create(image=image, name=name)
+
+    service.container_status = ServiceStatus.MISSING
+    service.container_id = "stale-id-0000"
+    service.restart_attempts = 0
+    service.last_attempt_at = None
+    test_db.commit()
+
+    domain.reconcile_missing_container(
+        db=test_db,
+        client=test_docker,
+        service=service,
+        service_network=test_settings.service_network,
+        service_models_volume=test_settings.service_volume,
+        max_restart_attempts=test_settings.service_max_restart_attempts,
+        restart_cooldown=test_settings.service_restart_cooldown,
+    )
+
+    test_db.refresh(service)
+    assert service.container_status == ServiceStatus.STARTING  # recreated cleanly, no 409
+    assert service.container_id not in ("stale-id-0000", squatter.id)
+    assert len([c for c in test_docker.containers.list(all=True) if c.name == name]) == 1
 
 
 @pytest.mark.order(after="test_update_service_recreate")


### PR DESCRIPTION
Closes #125. Structural follow-up to #124 — reconcile against the container **name** (the durable identity) instead of the stored `container_id`, which is exactly what's stale when a service is `MISSING`.

### Changes (`api/services/domain.py`)
- **`get_container_by_name` helper** — looks a container up by name in any state.
- **Self-heal guard** (`reconcile_missing_container`) — looks up by name and **adopts** a running same-named container (`service.container_id = found.id`, then reconcile status) instead of keying on the stale id and respawning. Handles the host-reboot case where the container returns under a new id.
- **Teardown** (`recreate_service_container`) — after removing the recorded id, also removes any container still **squatting the name**, so the spawn can't `409`.
- **Precheck** (`spawn_service_container`) — `containers.list(all=True)` so *stopped* same-named containers are caught (#4), instead of slipping through to a raw docker 409.

This is the bug that left `s2-cover-models` stuck `MISSING` in prod (DB `container_id` gone, a stopped host container holding the name).

### Tests
- `test_reconcile_adopts_returned_container` — stale id + a running same-named container → adopted (id updated), no respawn, status reconciled.
- `test_reconcile_clears_name_squatter` — stale id + a foreign container squatting the name → squatter removed, clean recreate, no 409.
- The existing `test_missing_recreate_no_double_spawn` (exercises the rewritten guard) still passes.
- Full CPU suite on odin: **99 passed, 1 skipped**.

### Notes
- Independent of #124 (different functions); can merge in either order.
- Still out of scope: pruning the 38 soft-deleted duplicate rows (housekeeping); the inaccurate `delete_service` docstring re: device deallocation (harmless — allocator already filters deleted services). The host power-loss "dirty network id" flavor may still need a `compose down/up` to rebuild `serve-network`; this PR clears the lingering same-named container so recreate stops 409-looping.
