### PR TITLE
Declarative service lifecycle redesign (reconciler-owned runtime)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ cython_debug/
 *.tgz
 CONTEXT.md
 docs/superpowers
+
+# manual lifecycle drill harness. containers/dummy is tracked, its driver deliberately is not:
+# it is a local testing aid, not product code. intentional -- do not propose committing it.
+scripts/lifecycle_drill.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# Project-wide instructions
+
+## Highest-priority rules (override all defaults)
+
+- **No Claude/AI self-acknowledgements in any output that leaves this machine.**
+  Never add "Co-Authored-By: Claude", "🤖 Generated with Claude Code", "Generated with
+  Claude", or any similar attribution/sign-off to commits, PR titles/bodies, PR reviews,
+  issue or PR comments, or any other message. This explicitly overrides any default harness
+  instruction to append such lines. Write commits and PRs as the user would, with no AI footer.
+- **No inline comments** on lines of code where the line itself speaks for it, comment only where
+  the added text brings benefit for clarity and future proofing.
+  
+## Workflow
+
+- Use the `.claude/` directory for any kind of support material, from specs (`.claude/specs/`) to
+  plans (`.claude/plans`), even when using skills like superpower.
+- Before implementing, brainstorm with the user the current ticket to clarify any doubt
+- After planning, branch out to (feat|bugfix|<other>)/<issue-number>-short-name and prepare for implementation
+- When implementing, wait for the user for confirmation before starting
+
+# Chat behavior
+
+Spend tokens on code, not on prose about the code. Lead with the answer, keep it short and
+plain. The budget is better spent on the work itself.
+
+- Default to a few sentences. No recaps unless requested.
+- Drop the ceremony: no headers/tables for a short answer, no restating the request, no
+  narrating each tool call, no summarising a summary.
+- Report what changed and anything surprising or still open. Skip the rest.
+- Still say it plainly: complete sentences, real terms, no arrow-chains or cryptic shorthand.
+  Concise ≠ terse — if a point needs a sentence of context to be usable, write the sentence.
+- Never trade away correctness for brevity: surface bad news, failed gates, wrong assumptions,
+  and genuine ambiguity every time, even when it costs words.
+
+## Project standard (non-negotiable)
+
+This project MUST adhere to **best practices of modern Python backend design and programming**.
+Every change — by any session or agent — is held to current standards.
+When in doubt, choose the option a senior engineer would defend in 2026, not the
+quickest patch. Review work against the checklist below before considering it done.
+
+## Stack
+
+- FastAPI for backend, using SQLAlchemy and alembic for migrations, pydantic for schemas
+- PostgreSQL as underlying database
+- Celery for async tasks using PostgreSQL as broker
+- Traefik for routing and dynamic discovery of services / reverse proxy
+
+## Definition of done
+
+- lint, typecheck, format and test pass. Check pre-commit-config and Makefile for commands
+- no `any`/dead code/stray logs
+- matches the specification.

--- a/alembic/versions/a1f6c9d40b72_service_healthcheck.py
+++ b/alembic/versions/a1f6c9d40b72_service_healthcheck.py
@@ -1,0 +1,28 @@
+"""service healthcheck
+
+Revision ID: a1f6c9d40b72
+Revises: b4cbad202c5e
+Create Date: 2026-08-11 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1f6c9d40b72"
+down_revision: str | None = "b4cbad202c5e"
+branch_labels: str | (Sequence[str] | None) = None
+depends_on: str | (Sequence[str] | None) = None
+
+
+def upgrade() -> None:
+    # nullable with no default: existing services keep the boot-grace uptime timer
+    op.add_column("service_resources", sa.Column("healthcheck", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("service_resources", "healthcheck")

--- a/alembic/versions/b4cbad202c5e_lifecycle_contract.py
+++ b/alembic/versions/b4cbad202c5e_lifecycle_contract.py
@@ -1,0 +1,29 @@
+"""lifecycle contract
+
+Revision ID: b4cbad202c5e
+Revises: c37d863f3180
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b4cbad202c5e"
+down_revision: str | None = "c37d863f3180"
+branch_labels: str | (Sequence[str] | None) = None
+depends_on: str | (Sequence[str] | None) = None
+
+
+def upgrade() -> None:
+    op.drop_column("services", "container_status")
+    op.execute("DROP TYPE servicestatus")
+
+
+def downgrade() -> None:
+    old = sa.Enum("starting", "active", "error", "stopped", "deleted", "missing", name="servicestatus")
+    old.create(op.get_bind(), checkfirst=True)
+    op.add_column("services", sa.Column("container_status", old, nullable=False, server_default="starting"))

--- a/alembic/versions/b4cbad202c5e_lifecycle_contract.py
+++ b/alembic/versions/b4cbad202c5e_lifecycle_contract.py
@@ -24,6 +24,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    old = sa.Enum("starting", "active", "error", "stopped", "deleted", "missing", name="servicestatus")
+    # the original servicestatus stored UPPERCASE member names (af7db8f0dc88_init) and gained
+    # MISSING in dd883257cf20; recreate it faithfully. prior status values are not recoverable and
+    # fall back to the server default.
+    old = sa.Enum("STARTING", "ACTIVE", "ERROR", "STOPPED", "DELETED", "MISSING", name="servicestatus")
     old.create(op.get_bind(), checkfirst=True)
-    op.add_column("services", sa.Column("container_status", old, nullable=False, server_default="starting"))
+    op.add_column("services", sa.Column("container_status", old, nullable=False, server_default="STARTING"))

--- a/alembic/versions/c37d863f3180_lifecycle_redesign_expand.py
+++ b/alembic/versions/c37d863f3180_lifecycle_redesign_expand.py
@@ -1,0 +1,56 @@
+"""lifecycle redesign expand
+
+Revision ID: c37d863f3180
+Revises: dd883257cf20
+Create Date: 2026-07-20 12:49:08.223067
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c37d863f3180"
+down_revision: str | None = "dd883257cf20"
+branch_labels: str | (Sequence[str] | None) = None
+depends_on: str | (Sequence[str] | None) = None
+
+desired = sa.Enum("available", "suspended", "retired", name="desiredstate")
+runtime = sa.Enum("ready", "warming", "idle", "recovering", "failed", "suspended", "retired", name="runtimestatus")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    desired.create(bind, checkfirst=True)
+    runtime.create(bind, checkfirst=True)
+
+    op.add_column("services", sa.Column("desired_state", desired, nullable=True))
+    op.add_column("services", sa.Column("runtime_status", runtime, nullable=True))
+
+    # backfill: intent from deleted_at; runtime projected from the old container_status
+    op.execute(
+        """
+        UPDATE services SET
+          desired_state = CASE WHEN deleted_at IS NOT NULL THEN 'retired' ELSE 'available' END::desiredstate,
+          runtime_status = CASE container_status
+            WHEN 'ACTIVE'   THEN 'ready'
+            WHEN 'STARTING' THEN 'warming'
+            WHEN 'STOPPED'  THEN 'idle'
+            WHEN 'MISSING'  THEN 'recovering'
+            WHEN 'ERROR'    THEN 'failed'
+            WHEN 'DELETED'  THEN 'retired'
+            ELSE 'warming'
+          END::runtimestatus
+        """
+    )
+    op.alter_column("services", "desired_state", nullable=False)
+    op.alter_column("services", "runtime_status", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("services", "runtime_status")
+    op.drop_column("services", "desired_state")
+    op.execute("DROP TYPE runtimestatus")
+    op.execute("DROP TYPE desiredstate")

--- a/alembic/versions/c37d863f3180_lifecycle_redesign_expand.py
+++ b/alembic/versions/c37d863f3180_lifecycle_redesign_expand.py
@@ -26,8 +26,10 @@ def upgrade() -> None:
     desired.create(bind, checkfirst=True)
     runtime.create(bind, checkfirst=True)
 
-    op.add_column("services", sa.Column("desired_state", desired, nullable=True))
-    op.add_column("services", sa.Column("runtime_status", runtime, nullable=True))
+    # server_default lets the still-running old code insert rows during the expand window
+    # (before contract flips ownership); the backfill below then corrects any placeholder rows
+    op.add_column("services", sa.Column("desired_state", desired, nullable=True, server_default="available"))
+    op.add_column("services", sa.Column("runtime_status", runtime, nullable=True, server_default="warming"))
 
     # backfill: intent from deleted_at; runtime projected from the old container_status
     op.execute(

--- a/containers/dummy/Dockerfile
+++ b/containers/dummy/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-alpine
+
+# curl so a service healthcheck can use the natural `CMD curl -f .../v2/health/ready` form
+RUN apk add --no-cache curl
+
+COPY server.py /server.py
+
+EXPOSE 8000
+# python receives the platform's `--load-model=<name>` args as argv and serves exactly those models
+ENTRYPOINT ["python", "-u", "/server.py"]

--- a/containers/dummy/server.py
+++ b/containers/dummy/server.py
@@ -1,0 +1,156 @@
+"""Dummy Triton-compatible server for exercising the reconciler lifecycle by hand.
+
+Speaks enough of the KServe v2 API that traefik routing and the /status projection behave like the
+real tritonserver, while boot time, health and exit behaviour are driven entirely by environment
+variables -- so every ObservedState the reconciler can produce is reachable on demand, without
+pulling the 19GB triton image or waiting for a real model load.
+
+The platform spawns services with `--load-model=<name>` arguments; those are parsed here so the
+model endpoints report exactly the models the service was created with.
+
+Environment:
+    DUMMY_BOOT_DELAY  seconds to wait before binding the port at all (default 0). Models a slow
+                      model load: the container is `running` but nothing is listening yet, which
+                      is precisely the window where an uptime-only readiness check lies.
+    DUMMY_LIFETIME    seconds to stay up before exiting (default 0 = forever).
+    DUMMY_EXIT_CODE   exit code used when DUMMY_LIFETIME elapses (default 0). 0 -> EXITED_OK,
+                      non-zero -> CRASHED.
+    DUMMY_HEALTHY     when false, /v2/health/ready serves 503 forever while the process stays
+                      alive -- a wedged server, which only becomes visible to the reconciler when
+                      the service carries a healthcheck.
+    DUMMY_PORT        listen port (default 8000, matching triton and the traefik loadBalancer url).
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SERVER_NAME = "triton-dummy"
+SERVER_VERSION = "2.36.0"
+EXTENSIONS = ["classification", "sequence", "model_repository", "schedule_policy", "statistics"]
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    return int(raw) if raw else default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    return raw not in ("0", "false", "no") if raw else default
+
+
+BOOT_DELAY = _env_int("DUMMY_BOOT_DELAY", 0)
+LIFETIME = _env_int("DUMMY_LIFETIME", 0)
+EXIT_CODE = _env_int("DUMMY_EXIT_CODE", 0)
+HEALTHY = _env_bool("DUMMY_HEALTHY", True)
+PORT = _env_int("DUMMY_PORT", 8000)
+
+MODELS = [arg.split("=", 1)[1] for arg in sys.argv[1:] if arg.startswith("--load-model=")]
+
+
+def _model_metadata(name: str) -> dict:
+    return {
+        "name": name,
+        "versions": ["1"],
+        "platform": "dummy",
+        "inputs": [{"name": "INPUT__0", "datatype": "FP32", "shape": [-1, 3]}],
+        "outputs": [{"name": "OUTPUT__0", "datatype": "FP32", "shape": [-1, 3]}],
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args) -> None:
+        sys.stdout.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+    def _send(self, code: int, payload: dict | None = None) -> None:
+        body = json.dumps(payload).encode() if payload is not None else b""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _route(self, path: str, method: str) -> tuple[int, dict | None]:
+        parts = [p for p in path.split("?")[0].strip("/").split("/") if p]
+        if not parts or parts[0] != "v2":
+            return 404, {"error": "not found"}
+
+        # /v2 -> server metadata
+        if len(parts) == 1:
+            return 200, {"name": SERVER_NAME, "version": SERVER_VERSION, "extensions": EXTENSIONS}
+
+        # /v2/health/{live,ready}
+        if parts[1] == "health" and len(parts) == 3:
+            if parts[2] == "live":
+                return 200, None  # the process is up; liveness never depends on DUMMY_HEALTHY
+            if parts[2] == "ready":
+                return (200, None) if HEALTHY else (503, {"error": "server not ready"})
+            return 404, {"error": "not found"}
+
+        # /v2/repository/index -> the models this service was told to load
+        if parts[1] == "repository" and parts[2:] == ["index"]:
+            return 200, [{"name": m, "version": "1", "state": "READY"} for m in MODELS]  # type: ignore[return-value]
+
+        if parts[1] == "models" and len(parts) >= 3:
+            name = parts[2]
+            if name not in MODELS:
+                return 404, {"error": f"Request for unknown model: '{name}' is not found"}
+            tail = parts[3:]
+            if not tail:
+                return 200, _model_metadata(name)
+            if tail == ["ready"]:
+                return (200, None) if HEALTHY else (503, {"error": "model not ready"})
+            if tail == ["config"]:
+                return 200, {"name": name, "platform": "dummy", "max_batch_size": 0}
+            if tail == ["stats"]:
+                return 200, {"model_stats": [{"name": name, "version": "1"}]}
+            if tail == ["infer"] and method == "POST":
+                return 200, {
+                    "model_name": name,
+                    "model_version": "1",
+                    "outputs": [{"name": "OUTPUT__0", "datatype": "FP32", "shape": [1, 3], "data": [0.0, 0.0, 0.0]}],
+                }
+        return 404, {"error": "not found"}
+
+    def do_GET(self) -> None:
+        code, payload = self._route(self.path, "GET")
+        self._send(code, payload)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        code, payload = self._route(self.path, "POST")
+        self._send(code, payload)
+
+
+def _exit_after(seconds: int, code: int) -> None:
+    time.sleep(seconds)
+    print(f"[dummy] lifetime {seconds}s elapsed, exiting with {code}", flush=True)
+    os._exit(code)
+
+
+def main() -> None:
+    print(f"[dummy] models={MODELS or '<none>'} boot_delay={BOOT_DELAY}s healthy={HEALTHY}", flush=True)
+    if BOOT_DELAY:
+        # deliberately before bind(): nothing is listening while the container is already `running`
+        print(f"[dummy] simulating model load for {BOOT_DELAY}s (port closed)", flush=True)
+        time.sleep(BOOT_DELAY)
+
+    if LIFETIME:
+        threading.Thread(target=_exit_after, args=(LIFETIME, EXIT_CODE), daemon=True).start()
+
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    print(f"[dummy] listening on 0.0.0.0:{PORT}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ x-backend-base: &backend-base
           - capabilities: ["gpu"]
             driver: nvidia
             count: all
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
   env_file:
     - .env
   labels:
@@ -85,6 +83,7 @@ services:
     image: ghcr.io/links-ads/serve-sentinel:${PROJECT_VERSION:-latest}
     volumes:
       - ./src:/app/src
+      - /var/run/docker.sock:/var/run/docker.sock
     container_name: serve-sentinel
     env_file:
       - .env

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,7 +63,7 @@ check_gpus() {
 start_sentinel() {
     echo "Starting Sentinel..."
     # --concurrency=1: the reconciler owns Docker; a single worker slot keeps one reconcile pass
-    # in flight at a time (belt-and-suspenders with the task's pg advisory lock)
+    # in flight at a time, alongside the task's pg advisory lock
     # strip any surrounding quotes: env_file may pass TARGET as the literal string "test"
     local target="${TARGET//\"/}"
     local worker_args=("--loglevel=${LOG_LEVEL:-info}" "--concurrency=1")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,8 +62,12 @@ check_gpus() {
 
 start_sentinel() {
     echo "Starting Sentinel..."
-    local worker_args=("--loglevel=${LOG_LEVEL:-info}")
-    if [ "$TARGET" != "test" ]; then
+    # --concurrency=1: the reconciler owns Docker; a single worker slot keeps one reconcile pass
+    # in flight at a time (belt-and-suspenders with the task's pg advisory lock)
+    # strip any surrounding quotes: env_file may pass TARGET as the literal string "test"
+    local target="${TARGET//\"/}"
+    local worker_args=("--loglevel=${LOG_LEVEL:-info}" "--concurrency=1")
+    if [ "$target" != "test" ]; then
         worker_args+=("--beat")
     fi
     exec uv run celery -A triton_serve.tasks worker "${worker_args[@]}"

--- a/src/triton_serve/api/allocations/domain.py
+++ b/src/triton_serve/api/allocations/domain.py
@@ -1,7 +1,7 @@
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from triton_serve.database.model import Machine, Service, ServiceStatus
+from triton_serve.database.model import Machine, RuntimeStatus, Service
 from triton_serve.database.schema import (
     DeviceAllocationSummarySchema,
     DeviceAllocationViewSchema,
@@ -12,7 +12,8 @@ from triton_serve.database.schema import (
     ServiceDeviceAllocationSchema,
 )
 
-_IN_USE = {ServiceStatus.STARTING, ServiceStatus.ACTIVE}
+# a service occupies its allocated resources whenever the reconciler intends a container up
+_IN_USE = {RuntimeStatus.READY, RuntimeStatus.WARMING, RuntimeStatus.RECOVERING}
 
 
 def get_resource_overview(db: Session) -> MachineAllocationSchema:
@@ -23,15 +24,15 @@ def get_resource_overview(db: Session) -> MachineAllocationSchema:
     all_services = db.query(Service).filter(Service.deleted_at.is_(None)).all()
 
     cpu_allocated = sum(s.resources.cpu_count for s in all_services if s.resources)
-    cpu_in_use = sum(s.resources.cpu_count for s in all_services if s.resources and s.container_status in _IN_USE)
+    cpu_in_use = sum(s.resources.cpu_count for s in all_services if s.resources and s.runtime_status in _IN_USE)
     mem_allocated = sum(s.resources.mem_size for s in all_services if s.resources)
-    mem_in_use = sum(s.resources.mem_size for s in all_services if s.resources and s.container_status in _IN_USE)
+    mem_in_use = sum(s.resources.mem_size for s in all_services if s.resources and s.runtime_status in _IN_USE)
 
     devices = []
     for device in machine.devices:
         active_allocs = [a for a in device.allocations if a.service.deleted_at is None]
         allocated_pct = sum(a.allocation_percentage for a in active_allocs)
-        in_use_pct = sum(a.allocation_percentage for a in active_allocs if a.service.container_status in _IN_USE)
+        in_use_pct = sum(a.allocation_percentage for a in active_allocs if a.service.runtime_status in _IN_USE)
 
         devices.append(
             DeviceAllocationViewSchema(
@@ -44,7 +45,7 @@ def get_resource_overview(db: Session) -> MachineAllocationSchema:
                     DeviceServiceSchema(
                         service_id=a.service_id,
                         service_name=a.service.service_name,
-                        container_status=a.service.container_status,
+                        runtime_status=a.service.runtime_status,
                         allocation_percentage=a.allocation_percentage,
                     )
                     for a in active_allocs
@@ -71,7 +72,7 @@ def get_service_allocation(db: Session, service_id: int) -> ServiceAllocationSch
     return ServiceAllocationSchema(
         service_id=service.service_id,
         service_name=service.service_name,
-        container_status=service.container_status,
+        runtime_status=service.runtime_status,
         cpu_count=res.cpu_count,
         mem_size=res.mem_size,
         devices=[

--- a/src/triton_serve/api/dto.py
+++ b/src/triton_serve/api/dto.py
@@ -58,6 +58,31 @@ class ModelUpdateBody(BaseModel):
         return v
 
 
+class ServiceHealthcheck(BaseModel):
+    """Optional container healthcheck. Without one a service is judged READY purely on uptime
+    (`service_boot_grace`), so a slow-booting image is reported ready before it can serve."""
+
+    test: list[str] = Field(
+        description="Docker healthcheck test, e.g. ['CMD', 'curl', '-f', 'http://localhost:8000/v2/health/ready']",
+        min_length=1,
+    )
+    interval: int = Field(gt=0, default=10, description="Seconds between probes")
+    timeout: int = Field(gt=0, default=5, description="Seconds before a probe is considered failed")
+    retries: int = Field(gt=0, default=3, description="Consecutive failures before the container is unhealthy")
+    start_period: int = Field(
+        ge=0,
+        default=60,
+        description="Grace seconds before failures start counting toward retries",
+    )
+
+    @field_validator("test")
+    @classmethod
+    def validate_test(cls, v: list[str]) -> list[str]:
+        if v[0] not in ("CMD", "CMD-SHELL", "NONE"):
+            raise ValueError("test must start with 'CMD', 'CMD-SHELL' or 'NONE'")
+        return v
+
+
 class ServiceCreateResources(BaseModel):
     gpus: float = Field(ge=0.0, default=0.0, description="Number of GPUs, float for fractional GPUs")
     shm_size: int = Field(gt=0, le=65536, default=256, description="Shared memory size in MB")
@@ -95,6 +120,7 @@ class ServiceUpdateBody(BaseModel):
     timeout: int | None = None
     priority: int | None = None
     resources: ServiceUpdateResources | None = None
+    healthcheck: ServiceHealthcheck | None = None
 
     @field_validator("models")
     @classmethod
@@ -112,6 +138,7 @@ class ServiceCreateBody(BaseModel):
     timeout: int = 3600  # in seconds
     priority: int = 1  # higher number means higher priority
     resources: ServiceCreateResources = ServiceCreateResources()
+    healthcheck: ServiceHealthcheck | None = None
 
     @field_validator("name")
     @classmethod

--- a/src/triton_serve/api/services/__init__.py
+++ b/src/triton_serve/api/services/__init__.py
@@ -126,6 +126,9 @@ def create_service(
     - `resources` (`Optional[ServiceResources]`): Resources to be allocated to the service.
     - `timeout` (`Optional[int]`): Timeout for the service. Defaults to `3600`.
     - `priority` (`Optional[int]`): Priority of the service. Defaults to `1`.
+    - `healthcheck` (`Optional[ServiceHealthcheck]`): Container healthcheck. Without one, the service
+      is reported `READY` once it has been up for `service_boot_grace` seconds, regardless of whether
+      it can actually serve.
 
     **Returns:**
     - `Service` (`ServiceSchema`): Information about the created service.
@@ -143,6 +146,7 @@ def create_service(
         service_priority=service_params.priority,
         model_infos=service_params.models,
         service_api_keys=settings.api_keys,
+        service_healthcheck=service_params.healthcheck,
     )
 
 
@@ -172,19 +176,43 @@ def delete_service(
 
 @router.post("/services/{service_id}/suspend", status_code=204, tags=["operations"])
 def suspend_service(service_id: int, db: Session = Depends(get_db), _: Any = Depends(require_admin)):
-    """Operator intent: keep the service off (no auto-wake). The reconciler stops it."""
+    """
+    Operator intent: keep the service off (no auto-wake). The reconciler stops it.
+
+    **Arguments:**
+    - `service_id` (`int`): The id of the service to suspend.
+
+    **Returns:**
+    - `None`
+    """
     domain.set_desired_state(db=db, service_id=service_id, desired=DesiredState.SUSPENDED)
 
 
 @router.post("/services/{service_id}/resume", status_code=204, tags=["operations"])
 def resume_service(service_id: int, db: Session = Depends(get_db), _: Any = Depends(require_admin)):
-    """Operator intent: make the service available again; records a wake so it comes up."""
+    """
+    Operator intent: make the service available again; records a wake so it comes up.
+
+    **Arguments:**
+    - `service_id` (`int`): The id of the service to resume.
+
+    **Returns:**
+    - `None`
+    """
     domain.set_desired_state(db=db, service_id=service_id, desired=DesiredState.AVAILABLE, wake=True)
 
 
 @router.post("/services/{service_id}/retry", status_code=204, tags=["operations"])
 def retry_service(service_id: int, db: Session = Depends(get_db), _: Any = Depends(require_admin)):
-    """Manual escape hatch for a FAILED service: reset the crash budget and wake it."""
+    """
+    Manual escape hatch for a FAILED service: reset the crash budget and wake it.
+
+    **Arguments:**
+    - `service_id` (`int`): The id of the service to retry.
+
+    **Returns:**
+    - `None`
+    """
     domain.reset_and_wake(db=db, service_id=service_id)
 
 

--- a/src/triton_serve/api/services/__init__.py
+++ b/src/triton_serve/api/services/__init__.py
@@ -11,7 +11,7 @@ from triton_serve.config import (
     get_settings,
     get_traefik,
 )
-from triton_serve.database.model import DesiredState, RuntimeStatus, ServiceStatus
+from triton_serve.database.model import DesiredState, RuntimeStatus
 from triton_serve.database.schema import ServiceSchema
 from triton_serve.extensions import get_db
 from triton_serve.security import require_admin, require_elevated, require_service
@@ -29,7 +29,7 @@ _RETRY_AFTER = "2"
 )
 def get_services(
     names: list[str] = Query(None),
-    statuses: list[ServiceStatus] = Query(None),
+    runtime_statuses: list[RuntimeStatus] = Query(None),
     db: Session = Depends(get_db),
     _: Any = Depends(require_elevated),
 ):
@@ -38,12 +38,12 @@ def get_services(
 
     **Arguments:**
     - `names` (`Optional[list[str]]`, optional): Names of the services to be retrieved. Defaults to `None`.
-    - `statuses` (`Optional[list[ServiceStatus]]`, optional): Status of the service. Defaults to `None`.
+    - `runtime_statuses` (`Optional[list[RuntimeStatus]]`, optional): Runtime status filter. Defaults to `None`.
 
     **Returns:**
     - `List[Service]`: A list of services.
     """
-    return domain.list_services(db=db, names=names, statuses=statuses)
+    return domain.list_services(db=db, names=names, runtime_statuses=runtime_statuses)
 
 
 @router.get(

--- a/src/triton_serve/api/services/__init__.py
+++ b/src/triton_serve/api/services/__init__.py
@@ -18,7 +18,9 @@ from triton_serve.security import require_admin, require_elevated, require_servi
 
 router = APIRouter()
 
-_RETRY_AFTER = "2"
+# retry cadence handed to traefik/clients while a service is not yet ready: one reconcile tick,
+# so a caller retries roughly once per chance the reconciler has to bring the service up
+_RETRY_AFTER = str(get_settings().sentinel_poll_interval)
 
 
 @router.get(
@@ -186,7 +188,15 @@ def retry_service(service_id: int, db: Session = Depends(get_db), _: Any = Depen
     domain.reset_and_wake(db=db, service_id=service_id)
 
 
-@router.get("/status/{service_name}", tags=["operations"])
+@router.get(
+    "/status/{service_name}",
+    tags=["operations"],
+    responses={
+        200: {"description": "Service is READY; forward the request."},
+        404: {"description": "No such service, or it is RETIRED."},
+        503: {"description": "Service is not ready (warming, idle, recovering, suspended, or failed)."},
+    },
+)
 def service_status(
     service_name: str,
     db: Session = Depends(get_db),
@@ -209,6 +219,9 @@ def service_status(
             domain.update_active_time(db=db, service=service)  # wake intent -> replica_target=1 next tick
             return Response(status_code=503, headers={"Retry-After": _RETRY_AFTER})
         case RuntimeStatus.WARMING | RuntimeStatus.RECOVERING:
+            # a client still polling through a slow boot keeps the service wanted, so the
+            # reconciler does not scale it back to zero mid-wake once inactivity elapses
+            domain.update_active_time(db=db, service=service)
             return Response(status_code=503, headers={"Retry-After": _RETRY_AFTER})
         case _:  # SUSPENDED, FAILED
             return Response(status_code=503)

--- a/src/triton_serve/api/services/__init__.py
+++ b/src/triton_serve/api/services/__init__.py
@@ -151,11 +151,13 @@ def create_service(
 )
 def delete_service(
     service_id: int,
+    traefik: TraefikConfigManager = Depends(get_traefik),
     db: Session = Depends(get_db),
     _: Any = Depends(require_admin),
 ):
     """
-    Soft-deletes a service (DB-only). The reconciler tears down the container and Traefik config.
+    Soft-deletes a service: removes its Traefik config now and marks it RETIRED; the reconciler
+    tears down the container out of band.
 
     **Arguments:**
     - `service_id` (`int`): The id of the service to be deleted.
@@ -163,7 +165,7 @@ def delete_service(
     **Returns:**
     - `None`
     """
-    domain.delete_service(db=db, service_id=service_id)
+    domain.delete_service(db=db, traefik=traefik, service_id=service_id)
 
 
 @router.post("/services/{service_id}/suspend", status_code=204, tags=["operations"])
@@ -187,7 +189,6 @@ def retry_service(service_id: int, db: Session = Depends(get_db), _: Any = Depen
 @router.get("/status/{service_name}", tags=["operations"])
 def service_status(
     service_name: str,
-    response: Response,
     db: Session = Depends(get_db),
     _: Any = Depends(require_service),
 ) -> Response:

--- a/src/triton_serve/api/services/__init__.py
+++ b/src/triton_serve/api/services/__init__.py
@@ -1,7 +1,6 @@
 from typing import Any
 
-from docker import DockerClient
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session
 
 from triton_serve.api.dto import ServiceCreateBody, ServiceUpdateBody
@@ -12,12 +11,14 @@ from triton_serve.config import (
     get_settings,
     get_traefik,
 )
-from triton_serve.database.model import ServiceStatus
+from triton_serve.database.model import DesiredState, RuntimeStatus, ServiceStatus
 from triton_serve.database.schema import ServiceSchema
-from triton_serve.extensions import docker_client, get_db
+from triton_serve.extensions import get_db
 from triton_serve.security import require_admin, require_elevated, require_service
 
 router = APIRouter()
+
+_RETRY_AFTER = "2"
 
 
 @router.get(
@@ -30,7 +31,6 @@ def get_services(
     names: list[str] = Query(None),
     statuses: list[ServiceStatus] = Query(None),
     db: Session = Depends(get_db),
-    docker: DockerClient = Depends(docker_client),
     _: Any = Depends(require_elevated),
 ):
     """
@@ -43,13 +43,7 @@ def get_services(
     **Returns:**
     - `List[Service]`: A list of services.
     """
-    services = domain.list_services(
-        db=db,
-        docker_client=docker,
-        names=names,
-        statuses=statuses,
-    )
-    return services
+    return domain.list_services(db=db, names=names, statuses=statuses)
 
 
 @router.get(
@@ -61,23 +55,18 @@ def get_services(
 def get_service(
     service_id: int,
     db: Session = Depends(get_db),
-    docker: DockerClient = Depends(docker_client),
     _: Any = Depends(require_elevated),
 ):
     """
-    Retrieves a specific service by name, if present.
+    Retrieves a specific service by id, if present.
 
     **Arguments:**
-    - `name` (`str`): The name of the service.
+    - `service_id` (`int`): The id of the service.
 
     **Returns:**
     - `Service`: The requested service.
     """
-    service = domain.get_service_by_id(
-        db=db,
-        docker_client=docker,
-        service_id=service_id,
-    )
+    service = domain.get_service_by_id(db=db, service_id=service_id)
     if service is None:
         raise HTTPException(status_code=404, detail=f"Service with ID={service_id} does not exist")
     return service
@@ -117,36 +106,35 @@ def get_service_config(
 def create_service(
     service_params: ServiceCreateBody,
     settings: AppSettings = Depends(get_settings),
-    docker: DockerClient = Depends(docker_client),
     traefik: TraefikConfigManager = Depends(get_traefik),
     db: Session = Depends(get_db),
     _: Any = Depends(require_admin),
 ):
     """
-    Creates a new service with the specified models.
+    Declaratively creates a new service. The reconciler spawns the container out of band.
+
+    Returns `201` before the container exists; the service comes up on the reconciler's next tick.
+    A bad image reference surfaces asynchronously as a `FAILED` runtime status, not a create error.
 
     **Arguments:**
     - `name` (`string`): The name of the service to be created.
     - `models` (`list[Model]`): The models to be served by the service.
-    - `docker_image` (`Optional[str]`): The docker image to be used for the service. Defaults to `tritonserver:23.07-py3`.
+    - `docker_image` (`Optional[str]`): The docker image to be used for the service.
     - `environment` (`Optional[dict]`): Environment variables to be passed to the service. Defaults to `{}`.
     - `resources` (`Optional[ServiceResources]`): Resources to be allocated to the service.
     - `timeout` (`Optional[int]`): Timeout for the service. Defaults to `3600`.
     - `priority` (`Optional[int]`): Priority of the service. Defaults to `1`.
 
     **Returns:**
-    - `Service` (`ServiceCreateSchema`): Information about the created service.
+    - `Service` (`ServiceSchema`): Information about the created service.
     """
     docker_image = service_params.docker_image or settings.service_default_image
     return domain.create_service(
         db=db,
-        client=docker,
         traefik=traefik,
         service_name=service_params.name,
         image_name=docker_image,
-        service_network=settings.service_network,
         service_url_prefix=settings.service_prefix,
-        service_models_volume=settings.service_volume,
         service_environment=service_params.environment,
         service_resources=service_params.resources,
         service_timeout=service_params.timeout,
@@ -158,19 +146,16 @@ def create_service(
 
 @router.delete(
     "/services/{service_id}",
-    status_code=202,
+    status_code=204,
     tags=["services"],
-    response_model=ServiceSchema,
 )
 def delete_service(
     service_id: int,
-    docker: DockerClient = Depends(docker_client),
-    traefik: TraefikConfigManager = Depends(get_traefik),
     db: Session = Depends(get_db),
     _: Any = Depends(require_admin),
 ):
     """
-    Deletes a service with the specified name.
+    Soft-deletes a service (DB-only). The reconciler tears down the container and Traefik config.
 
     **Arguments:**
     - `service_id` (`int`): The id of the service to be deleted.
@@ -178,156 +163,71 @@ def delete_service(
     **Returns:**
     - `None`
     """
-    return domain.delete_service(
-        db=db,
-        client=docker,
-        traefik=traefik,
-        service_id=service_id,
-    )
+    domain.delete_service(db=db, service_id=service_id)
 
 
-@router.post(
-    "/services/{service_id}/stop",
-    status_code=204,
-    tags=["operations"],
-)
-def stop_service(
-    service_id: int,
-    docker: DockerClient = Depends(docker_client),
-    db: Session = Depends(get_db),
-    _: Any = Depends(require_admin),
-):
-    """
-    Stops the container of a service with the specified id.
-
-    **Arguments:**
-    - `service_id` (`int`): The id of the service to be stopped.
-
-    **Returns:**
-    - `None`
-    """
-    domain.stop_service(
-        db=db,
-        client=docker,
-        service_id=service_id,
-    )
+@router.post("/services/{service_id}/suspend", status_code=204, tags=["operations"])
+def suspend_service(service_id: int, db: Session = Depends(get_db), _: Any = Depends(require_admin)):
+    """Operator intent: keep the service off (no auto-wake). The reconciler stops it."""
+    domain.set_desired_state(db=db, service_id=service_id, desired=DesiredState.SUSPENDED)
 
 
-@router.get(
-    "/status/{service_name}",
-    status_code=200,
-    tags=["operations"],
-)
-def check_service_status(
+@router.post("/services/{service_id}/resume", status_code=204, tags=["operations"])
+def resume_service(service_id: int, db: Session = Depends(get_db), _: Any = Depends(require_admin)):
+    """Operator intent: make the service available again; records a wake so it comes up."""
+    domain.set_desired_state(db=db, service_id=service_id, desired=DesiredState.AVAILABLE, wake=True)
+
+
+@router.post("/services/{service_id}/retry", status_code=204, tags=["operations"])
+def retry_service(service_id: int, db: Session = Depends(get_db), _: Any = Depends(require_admin)):
+    """Manual escape hatch for a FAILED service: reset the crash budget and wake it."""
+    domain.reset_and_wake(db=db, service_id=service_id)
+
+
+@router.get("/status/{service_name}", tags=["operations"])
+def service_status(
     service_name: str,
-    settings: AppSettings = Depends(get_settings),
+    response: Response,
     db: Session = Depends(get_db),
-    docker: DockerClient = Depends(docker_client),
     _: Any = Depends(require_service),
-) -> int:
-    """
-    Checks the status of a service, turning it on if it is stopped.
+) -> Response:
+    """traefik forwardAuth hook. Reads the persisted runtime_status ONLY -- never Docker.
 
-    **Returns:**
-    - `200` if the service is running,
-    - `202` if the service is starting,
-    - `503` if the service is cannot be started.
+    Not-ready never returns 2XX (a 2XX makes forwardAuth forward to a dead backend).
+    IDLE additionally records wake intent; the reconciler brings the service up out of band.
     """
-    service = domain.get_service_by_name(
-        db=db,
-        service_name=service_name,
-        docker_client=docker,
-    )
-    match service.container_status:
-        case ServiceStatus.ACTIVE:
+    service = domain.get_service_record_by_name(db=db, service_name=service_name)
+    if service is None or service.runtime_status == RuntimeStatus.RETIRED:
+        return Response(status_code=404)
+
+    match service.runtime_status:
+        case RuntimeStatus.READY:
             domain.update_active_time(db=db, service=service)
-            return 200
-        case ServiceStatus.STARTING:
-            domain.update_active_time(db=db, service=service)
-            return 202
-        case ServiceStatus.STOPPED:
-            domain.start_service(
-                db=db,
-                client=docker,
-                service=service,
-            )
-            return 202
-        case ServiceStatus.MISSING:
-            domain.refresh_service(
-                db=db,
-                docker_client=docker,
-                service_id=service.service_id,
-                service_network=settings.service_network,
-                service_models_volume=settings.service_volume,
-                max_restart_attempts=settings.service_max_restart_attempts,
-                restart_cooldown=settings.service_restart_cooldown,
-            )
-            db.refresh(service)
-            if service.container_status == ServiceStatus.ERROR:
-                raise HTTPException(status_code=503, detail=f"Service '{service_name}' is in error state")
-            return 202
-        case ServiceStatus.ERROR:
-            raise HTTPException(status_code=503, detail=f"Service '{service_name}' is in error state")
-        case _:
-            raise HTTPException(status_code=503, detail=f"Service '{service_name}' is unavailable")
-
-
-@router.post("/services/{service_id}/refresh", status_code=204, tags=["operations"])
-def refresh_service(
-    service_id: int,
-    force_recreate: bool = Query(False),
-    settings: AppSettings = Depends(get_settings),
-    docker: DockerClient = Depends(docker_client),
-    db: Session = Depends(get_db),
-    _: Any = Depends(require_admin),
-):
-    """
-    Refreshes the service with the specified id.
-
-    **Arguments:**
-    - `service_id` (`int`): The id of the service to be refreshed.
-    - `force_recreate` (`bool`): If True, tears down and recreates the container. Recovers from ERROR/DELETED states.
-
-    **Returns:**
-    - `None`
-    """
-    domain.refresh_service(
-        db=db,
-        docker_client=docker,
-        service_id=service_id,
-        service_network=settings.service_network,
-        service_models_volume=settings.service_volume,
-        force_recreate=force_recreate,
-    )
+            return Response(status_code=200)
+        case RuntimeStatus.IDLE:
+            domain.update_active_time(db=db, service=service)  # wake intent -> replica_target=1 next tick
+            return Response(status_code=503, headers={"Retry-After": _RETRY_AFTER})
+        case RuntimeStatus.WARMING | RuntimeStatus.RECOVERING:
+            return Response(status_code=503, headers={"Retry-After": _RETRY_AFTER})
+        case _:  # SUSPENDED, FAILED
+            return Response(status_code=503)
 
 
 @router.put("/services/{service_id}", status_code=200, tags=["services"], response_model=ServiceSchema)
 def update_service(
     service_id: int,
     update_params: ServiceUpdateBody,
-    recreate: bool = Query(False),
-    settings: AppSettings = Depends(get_settings),
-    docker: DockerClient = Depends(docker_client),
     db: Session = Depends(get_db),
     _: Any = Depends(require_admin),
 ):
     """
-    Updates service parameters. Optionally recreates the container immediately.
+    Updates service parameters (declarative). Changes take effect on the next (re)create.
 
     **Arguments:**
     - `service_id` (`int`): The id of the service to update.
     - `update_params` (`ServiceUpdateBody`): Partial update payload (all fields optional).
-    - `recreate` (`bool`): If True, recreates the container after applying changes.
 
     **Returns:**
     - `Service`: The updated service.
     """
-    return domain.update_service(
-        db=db,
-        client=docker,
-        service_id=service_id,
-        update_body=update_params,
-        service_network=settings.service_network,
-        service_models_volume=settings.service_volume,
-        recreate=recreate,
-    )
+    return domain.update_service(db=db, service_id=service_id, update_body=update_params)

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -562,15 +562,17 @@ def create_service(
         raise e
 
 
-def delete_service(db: Session, service_id: int) -> None:
-    """Soft-deletes a service in the database only (Option A).
+def delete_service(db: Session, traefik: TraefikConfigManager, service_id: int) -> None:
+    """Soft-deletes a service (Option A): DB record plus synchronous Traefik teardown.
 
-    Stamps deleted_at and marks the service RETIRED. Capacity is released automatically because
-    allocation/capacity queries filter deleted_at IS NULL. The reconciler's REMOVE->FINALIZE path
-    tears down the container and Traefik config out of band.
+    Removes the Traefik config now (symmetric with create writing it synchronously), stamps
+    deleted_at, and marks the service RETIRED. Capacity is released automatically because
+    allocation/capacity queries filter deleted_at IS NULL. The reconciler removes the container
+    out of band on its next tick.
 
     Args:
         db (Session): The database session.
+        traefik (TraefikConfigManager): The Traefik config manager.
         service_id (int): The ID of the service.
 
     Raises:
@@ -579,9 +581,10 @@ def delete_service(db: Session, service_id: int) -> None:
     service = db.get(Service, service_id)
     if service is None or service.deleted_at is not None:
         raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
+    traefik.delete(service_name=service.service_name)
     service.deleted_at = datetime.now(tz=timezone.utc)
     service.desired_state = DesiredState.RETIRED
-    db.commit()  # reconciler REMOVE->FINALIZE tears down container + traefik out of band
+    db.commit()
 
 
 def update_active_time(db: Session, service: Service):

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -5,12 +5,12 @@ from itertools import chain
 from typing import cast
 
 from docker import DockerClient
-from docker.errors import APIError, ImageNotFound, NotFound, NullResource
+from docker.errors import APIError, ImageNotFound, NotFound
 from docker.models.containers import Container
 from docker.models.images import Image
 from docker.types import DeviceRequest
 from fastapi import HTTPException
-from sqlalchemy import Engine, func, or_, select, text
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from triton_serve.api.dto import ServiceCreateBody, ServiceCreateResources, ServiceUpdateBody
@@ -26,7 +26,6 @@ from triton_serve.database.model import (
     RuntimeStatus,
     Service,
     ServiceResources,
-    ServiceStatus,
     utcnow,
 )
 
@@ -84,7 +83,7 @@ def rebuild_service_config(
 def list_services(
     db: Session,
     names: list[str] | None = None,
-    statuses: list[ServiceStatus] | None = None,
+    runtime_statuses: list[RuntimeStatus] | None = None,
 ):
     """Returns all non-deleted services from the database.
 
@@ -93,7 +92,7 @@ def list_services(
     Args:
         db (Session): The database session.
         names (list[str] | None): Optional filter on service names.
-        statuses (list[ServiceStatus] | None): Optional filter on container status.
+        runtime_statuses (list[RuntimeStatus] | None): Optional filter on runtime status.
 
     Returns:
         list[Service]: The list of services.
@@ -101,8 +100,8 @@ def list_services(
     statement = db.query(Service).filter(Service.deleted_at.is_(None))
     if names:
         statement = statement.filter(Service.service_name.in_(names))
-    if statuses:
-        statement = statement.filter(Service.container_status.in_(statuses))
+    if runtime_statuses:
+        statement = statement.filter(Service.runtime_status.in_(runtime_statuses))
     return statement.all()
 
 
@@ -278,45 +277,6 @@ def get_service_image(docker_client: DockerClient, image_name: str) -> Image:
         raise HTTPException(status_code=412, detail=f"Cannot retrieve image: {e.explanation}") from e
 
 
-def check_service_status(db: Session, docker_client: DockerClient, service: Service):
-    """Checks the status of a service, querying the docker daemon, and updating the database.
-
-    Args:
-        db (Session): The database session.
-        docker_client (DockerClient): The docker client.
-        service (Service): The service to check.
-    """
-    try:
-        container = docker_client.containers.get(service.container_id)
-        if container.status == "exited" and service.container_status not in (
-            ServiceStatus.STOPPED,
-            ServiceStatus.ERROR,
-        ):
-            state = docker_client.api.inspect_container(service.container_id).get("State")
-            exit_code = state.get("ExitCode", 0)
-            service.container_status = ServiceStatus.STOPPED if exit_code == 0 else ServiceStatus.ERROR
-        elif container.status == "running" and service.container_status != ServiceStatus.ACTIVE:
-            service.container_status = ServiceStatus.ACTIVE
-            service.restart_attempts = 0
-        db.commit()
-        db.refresh(service)
-        return service
-    except NotFound, NullResource:
-        # the container object is gone. only a previously-running service can go MISSING:
-        # transitioning from a terminal/managed state (ERROR, STOPPED) would let the sentinel
-        # revive services the user stopped or that already exhausted their restart budget.
-        # deleted_at is left untouched — deletion is a user-only action.
-        if service.container_status in (ServiceStatus.ACTIVE, ServiceStatus.STARTING):
-            service.container_status = ServiceStatus.MISSING
-            db.commit()
-            db.refresh(service)
-        return service
-    except APIError as e:
-        service.container_status = ServiceStatus.ERROR
-        db.commit()
-        raise HTTPException(status_code=e.status_code or 500, detail=str(e)) from e
-
-
 def spawn_service_container(
     client: DockerClient,
     image_id: str,
@@ -483,7 +443,6 @@ def create_service_entry(
         service_image=image_name,
         inactivity_timeout=service_timeout,
         priority=service_priority,
-        container_status=ServiceStatus.STARTING,
         created_at=datetime.now(tz=timezone.utc),
         last_active_time=datetime.now(tz=timezone.utc),
     )
@@ -625,25 +584,6 @@ def delete_service(db: Session, service_id: int) -> None:
     db.commit()  # reconciler REMOVE->FINALIZE tears down container + traefik out of band
 
 
-def start_service(
-    db: Session,
-    client: DockerClient,
-    service: Service,
-) -> None:
-    try:
-        LOG.debug(f"Starting service {service.service_id}...")
-        client.containers.get(service.container_id).start()
-        service.container_status = ServiceStatus.ACTIVE
-        service.last_active_time = datetime.now(tz=timezone.utc)
-        db.commit()
-    except NotFound:
-        raise HTTPException(status_code=404, detail="Service not found")
-    except Exception as e:
-        db.rollback()
-        LOG.debug(f"Error starting container: {str(e)}")
-        raise HTTPException(status_code=503, detail="Error restarting service")
-
-
 def update_active_time(db: Session, service: Service):
     """Updates the last active time of a service.
 
@@ -653,25 +593,6 @@ def update_active_time(db: Session, service: Service):
     """
     service.last_active_time = datetime.now(tz=timezone.utc)
     db.commit()
-
-
-def stop_service(
-    db: Session,
-    client: DockerClient,
-    service_id: int,
-) -> None:
-    try:
-        LOG.debug(f"Stopping service {service_id}...")
-        service = get_service_by_id(db=db, service_id=service_id)
-        assert service is not None, f"Service {service_id} could not be returned"
-        client.containers.get(service.container_id).stop()
-        service.container_status = ServiceStatus.STOPPED
-        db.commit()
-    except NotFound:
-        raise HTTPException(status_code=404, detail="Service not found")
-    except Exception as e:
-        db.rollback()
-        raise HTTPException(status_code=500, detail=f"Error stopping service: {str(e)}")
 
 
 def recreate_service_container(
@@ -730,7 +651,6 @@ def recreate_service_container(
         )
 
         service.container_id = str(container_id)
-        service.container_status = ServiceStatus.STARTING
         db.commit()
         db.refresh(service)
         return service
@@ -741,138 +661,6 @@ def recreate_service_container(
     except APIError as e:
         db.rollback()
         raise HTTPException(status_code=e.status_code or 500, detail=f"Error recreating service: {str(e)}") from e
-
-
-def reconcile_missing_container(
-    db: Session,
-    client: DockerClient,
-    service: Service,
-    service_network: str,
-    service_models_volume: str,
-    max_restart_attempts: int,
-    restart_cooldown: int,
-) -> None:
-    """Recreates a MISSING container under a single-flight, budget-bounded policy.
-
-    Mechanism (the actual respawn) lives in recreate_service_container; this function
-    only decides *whether* to recreate. A session-level advisory lock guarantees a single
-    in-flight reconciliation per service so concurrent on-demand and background callers do
-    not double-spawn. The attempt counter is committed before spawning so a failing image
-    still counts toward the budget; exhaustion lands the service in a recoverable ERROR.
-    """
-    lock_key = service.service_id
-    # Hold the advisory lock on a dedicated AUTOCOMMIT connection for the whole critical
-    # section. A session-level lock is bound to its backend connection; the ORM session
-    # bounces connections on every commit (the mid-flight bookkeeping commit below), so the
-    # lock must NOT live on the session's connection or the finally-unlock could target a
-    # different backend and leak the lock.
-    # the session is bound to the Engine (sessionmaker(bind=engine)); narrow the
-    # Engine | Connection union accordingly for the dedicated lock connection.
-    engine = cast(Engine, db.get_bind())
-    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as lock_conn:
-        acquired = lock_conn.execute(text("SELECT pg_try_advisory_lock(:k)"), {"k": lock_key}).scalar()
-        if not acquired:
-            LOG.debug("Reconciliation already in progress for service %s, skipping", service.service_id)
-            return
-        try:
-            # self-heal guard: a container under this service's name may already be up. it can
-            # come back under a NEW id (host reboot), so look it up by name, not the stale id.
-            # adopt a running one and just reconcile status; a dead one is cleared on recreate.
-            existing = get_container_by_name(client, service.service_name)
-            if existing is not None and existing.status == "running":
-                if service.container_id != existing.id:
-                    service.container_id = existing.id  # type: ignore
-                check_service_status(db=db, docker_client=client, service=service)
-                return
-
-            now = datetime.now(tz=timezone.utc)
-            if (
-                service.last_attempt_at is not None
-                and (now - service.last_attempt_at).total_seconds() > restart_cooldown
-            ):
-                service.restart_attempts = 0
-
-            if service.restart_attempts >= max_restart_attempts:
-                service.container_status = ServiceStatus.ERROR
-                db.commit()
-                db.refresh(service)
-                LOG.warning("Service %s exhausted restart budget, marking ERROR", service.service_id)
-                return
-
-            # record the attempt before spawning so a broken image cannot retry forever
-            service.restart_attempts += 1
-            service.last_attempt_at = now
-            db.commit()
-
-            try:
-                recreate_service_container(db, client, service, service_network, service_models_volume)
-            except HTTPException as e:
-                # leave the service MISSING; the next attempt proceeds until the budget exhausts
-                db.rollback()
-                LOG.warning(
-                    "Recreate attempt %d for service %s failed: %s",
-                    service.restart_attempts,
-                    service.service_id,
-                    e.detail,
-                )
-        finally:
-            lock_conn.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": lock_key})
-
-
-def refresh_service(
-    db: Session,
-    service_id: int,
-    docker_client: DockerClient,
-    service_network: str,
-    service_models_volume: str,
-    force_recreate: bool = False,
-    max_restart_attempts: int = 3,
-    restart_cooldown: int = 600,
-) -> None:
-    if (service := get_service_by_id(db=db, service_id=service_id)) is None:
-        raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
-
-    LOG.debug(
-        "Refreshing service %s (%d), status: %s",
-        service.service_name,
-        service.service_id,
-        service.container_status,
-    )
-
-    if force_recreate:
-        if service.deleted_at is not None:
-            service.deleted_at = None  # type: ignore
-        recreate_service_container(db, docker_client, service, service_network, service_models_volume)
-        return
-
-    # if service is either active, we need to stop and start it again
-    if service.container_status in (ServiceStatus.ACTIVE, ServiceStatus.STARTING):
-        stop_service(db=db, client=docker_client, service_id=service_id)
-        start_service(db=db, client=docker_client, service=service)
-        LOG.debug("Service %s with id %s has been refreshed", service.service_name, service.service_id)
-    elif service.container_status == ServiceStatus.MISSING:
-        reconcile_missing_container(
-            db=db,
-            client=docker_client,
-            service=service,
-            service_network=service_network,
-            service_models_volume=service_models_volume,
-            max_restart_attempts=max_restart_attempts,
-            restart_cooldown=restart_cooldown,
-        )
-    elif service.container_status in (ServiceStatus.DELETED, ServiceStatus.ERROR):
-        LOG.debug(
-            "Could not refresh the service %s with id %s: %s",
-            service.service_name,
-            service.service_id,
-            service.container_status,
-        )
-        raise HTTPException(
-            status_code=409, detail=f"Service '{service.service_name}'status: {service.container_status}"
-        )
-    # ServiceStatus.STOPPED case. We don't need to restart, it will refresh automatically when it will be called
-    else:
-        LOG.debug("No need to refresh")
 
 
 def update_service(

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -18,10 +18,12 @@ from triton_serve.api.models.domain import get_single_model
 from triton_serve.config.traefik import TraefikConfigManager
 from triton_serve.database.model import (
     APIKey,
+    DesiredState,
     Device,
     DeviceAllocation,
     KeyType,
     Model,
+    RuntimeStatus,
     Service,
     ServiceResources,
     ServiceStatus,
@@ -81,14 +83,17 @@ def rebuild_service_config(
 
 def list_services(
     db: Session,
-    docker_client: DockerClient,
     names: list[str] | None = None,
     statuses: list[ServiceStatus] | None = None,
 ):
-    """Returns a list of all services.
+    """Returns all non-deleted services from the database.
+
+    Read-only: returns the persisted runtime_status without touching Docker.
 
     Args:
         db (Session): The database session.
+        names (list[str] | None): Optional filter on service names.
+        statuses (list[ServiceStatus] | None): Optional filter on container status.
 
     Returns:
         list[Service]: The list of services.
@@ -98,28 +103,24 @@ def list_services(
         statement = statement.filter(Service.service_name.in_(names))
     if statuses:
         statement = statement.filter(Service.container_status.in_(statuses))
-    services = statement.all()
-    return [check_service_status(db=db, docker_client=docker_client, service=service) for service in services]
+    return statement.all()
 
 
-def get_service_by_id(db: Session, service_id: int, docker_client: DockerClient | None = None):
-    """Returns a specific service by id, if present.
+def get_service_by_id(db: Session, service_id: int) -> Service | None:
+    """Returns a specific service by id, if present. Read-only, no Docker call.
 
     Args:
         db (Session): The database session.
         service_id (int): The id of the service.
 
     Returns:
-        Service: The requested service.
+        Service | None: The requested service, or None if absent.
     """
-    service = db.get(Service, ident=service_id)
-    if docker_client is not None and service is not None:
-        return check_service_status(db=db, docker_client=docker_client, service=service)
-    return service
+    return db.get(Service, ident=service_id)
 
 
-def get_service_by_name(db: Session, service_name: str, docker_client: DockerClient | None = None):
-    """Returns a specific service by name, if present.
+def get_service_by_name(db: Session, service_name: str) -> Service:
+    """Returns a specific non-deleted service by name. Read-only, no Docker call.
 
     Args:
         db (Session): The database session.
@@ -128,7 +129,6 @@ def get_service_by_name(db: Session, service_name: str, docker_client: DockerCli
     Returns:
         Service: The requested service.
     """
-    # get any service with the specified name, not deleted
     service = (
         db.query(Service)
         .filter(
@@ -139,9 +139,33 @@ def get_service_by_name(db: Session, service_name: str, docker_client: DockerCli
     )
     if service is None:
         raise HTTPException(status_code=404, detail=f"No active service named '{service_name}'")
-    if docker_client is not None:
-        return check_service_status(db=db, docker_client=docker_client, service=service)
     return service
+
+
+def get_service_record_by_name(db: Session, service_name: str) -> Service | None:
+    """Pure DB lookup for the status projection hook. No Docker call."""
+    return db.query(Service).filter(Service.service_name == service_name, Service.deleted_at.is_(None)).one_or_none()
+
+
+def set_desired_state(db: Session, service_id: int, desired: DesiredState, wake: bool = False) -> None:
+    service = db.get(Service, service_id)
+    if service is None or service.deleted_at is not None:
+        raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
+    service.desired_state = desired
+    if wake:
+        service.last_active_time = datetime.now(tz=timezone.utc)
+    db.commit()
+
+
+def reset_and_wake(db: Session, service_id: int) -> None:
+    service = db.get(Service, service_id)
+    if service is None or service.deleted_at is not None:
+        raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
+    service.restart_attempts = 0
+    service.last_attempt_at = None
+    service.last_active_time = datetime.now(tz=timezone.utc)
+    service.runtime_status = RuntimeStatus.RECOVERING
+    db.commit()
 
 
 def get_service_config(db: Session, service_id: int) -> ServiceCreateBody:
@@ -504,12 +528,9 @@ def create_device_allocations(
 
 def create_service(
     db: Session,
-    client: DockerClient,
     traefik: TraefikConfigManager,
     service_name: str,
     image_name: str,
-    service_network: str,
-    service_models_volume: str,
     service_url_prefix: str,
     service_environment: dict[str, str],
     service_resources: ServiceCreateResources,
@@ -518,39 +539,35 @@ def create_service(
     model_infos: list[str],
     service_api_keys: list[str] | None = None,
 ) -> Service:
-    """
-    Creates a Triton docker container loading the specified models.
+    """Declaratively creates a service record; the reconciler spawns the container out of band.
+
+    No Docker call in the request path: the API is a desired-state store. The record persists
+    with desired_state=AVAILABLE and runtime_status=WARMING, and the reconciler pulls the image
+    and spawns the container on its next tick (surfacing a bad image ref as FAILED, not a 4xx here).
 
     Args:
         db (Session): The database session.
-        client (DockerClient): The Docker client.
         traefik (TraefikConfigManager): The Traefik config manager.
         service_name (str): The name of the service.
         image_name (str): The name of the Docker image to use.
-        service_network (str): The name of the Docker network to use.
-        service_models_volume (Path): The path to the model repository or a volume name.
         service_url_prefix (str): The URL prefix to use for the service.
         service_environment (dict[str, str]): The environment variables to pass to the container.
         service_resources (ServiceCreateResources): The resources to use for the container.
         service_timeout (int): The timeout for the service.
         service_priority (int): The priority for the service.
-        service_api_keys (list[str], optional): The list of API keys to use for the service.
         model_infos (list): The list of models to load.
+        service_api_keys (list[str], optional): The list of API keys to use for the service.
 
     Returns:
         Service: The created service.
 
     Raises:
-        HTTPException: If the service could not be created.
+        HTTPException: If capacity validation fails or the service could not be created.
     """
     try:
-        # Validate image
         assert image_name, "No image specified"
-        image = get_service_image(client, image_name)
-        assert image.id is not None, f"Invalid image ID for {image_name}"
         model_instances = validate_models(db, model_infos)
         device_infos, device_percent = get_allocable_devices(db, required_gpus=service_resources.gpus)
-        # Create service entry in database
         service = create_service_entry(
             db=db,
             service_name=service_name,
@@ -561,28 +578,12 @@ def create_service(
             service_environment=service_environment,
             model_instances=model_instances,
         )
-        # Create device allocations
         create_device_allocations(
             db=db,
             service_id=service.service_id,
             device_infos=device_infos,
             device_percent=device_percent,
         )
-        # Spawn docker container
-        container_id = spawn_service_container(
-            client=client,
-            image_id=image.id,
-            worker_name=service_name,
-            worker_network=service_network,
-            worker_volume=service_models_volume,
-            models=model_instances,
-            devices=device_infos,
-            resources=service_resources,
-            environment=service_environment,
-        )
-
-        # Update service with container ID and configure Traefik from database truth
-        service.container_id = str(container_id)
         rebuild_service_config(
             db=db,
             traefik=traefik,
@@ -590,7 +591,6 @@ def create_service(
             service_prefix=service_url_prefix,
             default_keys=service_api_keys or [],
         )
-        # commit changes to be persisted
         db.commit()
         db.refresh(service)
         return service
@@ -598,78 +598,31 @@ def create_service(
     except AssertionError as e:
         db.rollback()
         raise HTTPException(status_code=409, detail=f"Error creating service: {str(e)}") from e
-    except APIError as e:
-        db.rollback()
-        raise HTTPException(status_code=e.status_code or 500, detail=f"Error creating service: {str(e)}") from e
     except Exception as e:
         db.rollback()
         raise e
 
 
-def delete_service(
-    db: Session,
-    client: DockerClient,
-    traefik: TraefikConfigManager,
-    service_id: int,
-) -> Service:
-    """
-    Soft-deletes a service: removes its Docker container and Traefik config and stamps deleted_at.
-    Device allocations are retained on the row but ignored while deleted (the allocator filters
-    out deleted services), so capacity is effectively released without dropping the records.
+def delete_service(db: Session, service_id: int) -> None:
+    """Soft-deletes a service in the database only (Option A).
+
+    Stamps deleted_at and marks the service RETIRED. Capacity is released automatically because
+    allocation/capacity queries filter deleted_at IS NULL. The reconciler's REMOVE->FINALIZE path
+    tears down the container and Traefik config out of band.
 
     Args:
         db (Session): The database session.
-        client (DockerClient): The docker client.
-        traefik (TraefikConfigManager): The traefik config manager.
         service_id (int): The ID of the service.
 
-    Returns:
-        Service: The deleted service.
-
     Raises:
-        HTTPException: If the service doesn't exist or if there's an error during deletion.
+        HTTPException: If the service does not exist or is already deleted.
     """
-    try:
-        # check if service exists
-        if (service := get_service_by_id(db=db, docker_client=client, service_id=service_id)) is None:
-            raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
-
-        current_time = datetime.now(tz=timezone.utc)
-
-        # Handle the Docker container
-        if service.container_id:
-            try:
-                container = client.containers.get(service.container_id)
-                container.remove(force=True)  # This stops and removes the container
-            except NotFound:
-                LOG.warning(f"Container for service {service_id} not found. It may have been already removed.")
-            except APIError as e:
-                LOG.error(f"Error removing Docker container for service {service_id}: {str(e)}")
-                service.container_status = ServiceStatus.ERROR
-                raise HTTPException(status_code=500, detail=f"Error removing Docker container: {str(e)}.")
-
-        # Update service status
-        service.deleted_at = current_time
-        service.container_status = ServiceStatus.DELETED
-        service.container_id = None  # type: ignore - Clear the container ID as it's been removed
-
-        # Remove traefik config
-        try:
-            traefik.delete(service_name=service.service_name)
-        except Exception as e:
-            LOG.error(f"Error removing Traefik config for service {service_id}: {str(e)}")
-
-        # Commit the changes
-        db.commit()
-        db.refresh(service)
-        return service
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        db.rollback()
-        LOG.exception(f"Unexpected error while deleting service {service_id}")
-        raise HTTPException(status_code=500, detail=f"Unexpected error deleting service: {str(e)}")
+    service = db.get(Service, service_id)
+    if service is None or service.deleted_at is not None:
+        raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
+    service.deleted_at = datetime.now(tz=timezone.utc)
+    service.desired_state = DesiredState.RETIRED
+    db.commit()  # reconciler REMOVE->FINALIZE tears down container + traefik out of band
 
 
 def start_service(
@@ -709,7 +662,7 @@ def stop_service(
 ) -> None:
     try:
         LOG.debug(f"Stopping service {service_id}...")
-        service = get_service_by_id(db=db, docker_client=client, service_id=service_id)
+        service = get_service_by_id(db=db, service_id=service_id)
         assert service is not None, f"Service {service_id} could not be returned"
         client.containers.get(service.container_id).stop()
         service.container_status = ServiceStatus.STOPPED
@@ -876,7 +829,7 @@ def refresh_service(
     max_restart_attempts: int = 3,
     restart_cooldown: int = 600,
 ) -> None:
-    if (service := get_service_by_id(db=db, service_id=service_id, docker_client=docker_client)) is None:
+    if (service := get_service_by_id(db=db, service_id=service_id)) is None:
         raise HTTPException(status_code=404, detail=f"Service with id {service_id} does not exist")
 
     LOG.debug(
@@ -924,23 +877,18 @@ def refresh_service(
 
 def update_service(
     db: Session,
-    client: DockerClient,
     service_id: int,
     update_body: ServiceUpdateBody,
-    service_network: str,
-    service_models_volume: str,
-    recreate: bool = False,
 ) -> Service:
-    """Updates a service's configuration and optionally recreates its container.
+    """Applies a partial configuration change to a service record (declarative, no Docker).
+
+    Container-affecting changes land in the record and take effect the next time the reconciler
+    (re)creates the container; there is no synchronous recreate in the request path.
 
     Args:
         db (Session): The database session.
-        client (DockerClient): The Docker client.
         service_id (int): The ID of the service to update.
         update_body (ServiceUpdateBody): The partial update payload.
-        service_network (str): The Docker network name.
-        service_models_volume (str): The volume name or path for models.
-        recreate (bool): If True, recreate the container after updating. Defaults to False.
 
     Returns:
         Service: The updated service.
@@ -953,7 +901,6 @@ def update_service(
             raise HTTPException(status_code=409, detail="cannot update a deleted service")
 
         if update_body.docker_image:
-            get_service_image(client, update_body.docker_image)
             service.service_image = update_body.docker_image
         if update_body.timeout is not None:
             service.inactivity_timeout = update_body.timeout
@@ -983,22 +930,14 @@ def update_service(
             service.models.extend(new_model_instances)
 
         if gpu_changed:
-            if service.container_status in (ServiceStatus.ACTIVE, ServiceStatus.STARTING):
-                stop_service(db=db, client=client, service_id=service_id)
             for alloc in service.device_allocations:
                 db.delete(alloc)
             db.flush()
             device_infos, device_percent = get_allocable_devices(db, required_gpus=new_gpus)
             create_device_allocations(db, service.service_id, device_infos, device_percent)
 
-        db.flush()
-
-        if recreate:
-            recreate_service_container(db, client, service, service_network, service_models_volume)
-        else:
-            db.commit()
-            db.refresh(service)
-
+        db.commit()
+        db.refresh(service)
         return service
 
     except HTTPException:
@@ -1006,9 +945,6 @@ def update_service(
     except AssertionError as e:
         db.rollback()
         raise HTTPException(status_code=409, detail=f"Error updating service: {str(e)}") from e
-    except APIError as e:
-        db.rollback()
-        raise HTTPException(status_code=e.status_code or 500, detail=f"Error updating service: {str(e)}") from e
     except Exception as e:
         db.rollback()
         raise e

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
-from triton_serve.api.dto import ServiceCreateBody, ServiceCreateResources, ServiceUpdateBody
+from triton_serve.api.dto import ServiceCreateBody, ServiceCreateResources, ServiceHealthcheck, ServiceUpdateBody
 from triton_serve.api.models.domain import get_single_model
 from triton_serve.config.traefik import TraefikConfigManager
 from triton_serve.database.model import (
@@ -177,6 +177,7 @@ def get_service_config(db: Session, service_id: int) -> ServiceCreateBody:
         environment=res.environment_variables or {},
         timeout=service.inactivity_timeout,
         priority=service.priority,
+        healthcheck=ServiceHealthcheck(**res.healthcheck) if res.healthcheck else None,
         resources=ServiceCreateResources(
             gpus=gpus,
             shm_size=res.shm_size,
@@ -254,6 +255,24 @@ def get_service_image(docker_client: DockerClient, image_name: str) -> Image:
         raise HTTPException(status_code=412, detail=f"Cannot retrieve image: {e.explanation}") from e
 
 
+def docker_healthcheck(healthcheck: dict | None) -> dict | None:
+    """Converts a stored healthcheck (seconds, snake_case) to the docker API shape (ns, PascalCase).
+
+    Services store the user-facing shape so it round-trips through the API unchanged; docker only
+    accepts durations in nanoseconds. Returns None when the service has no healthcheck configured,
+    which leaves the container without one and falls back to the boot-grace timer in `observe`.
+    """
+    if not healthcheck:
+        return None
+    return {
+        "Test": healthcheck["test"],
+        "Interval": int(healthcheck["interval"] * 1e9),
+        "Timeout": int(healthcheck["timeout"] * 1e9),
+        "Retries": healthcheck["retries"],
+        "StartPeriod": int(healthcheck["start_period"] * 1e9),
+    }
+
+
 def spawn_service_container(
     client: DockerClient,
     image_id: str,
@@ -264,6 +283,7 @@ def spawn_service_container(
     resources: ServiceCreateResources,
     devices: list | None = None,
     environment: dict[str, str] | None = None,
+    healthcheck: dict | None = None,
 ):
     """Spawns a triton worker container.
 
@@ -279,6 +299,7 @@ def spawn_service_container(
         resources (ServiceCreateResources): The resources to use for the container.
         devices (list[str], optional): The list of devices to use. Defaults to None.
         environment (dict[str, str], optional): The environment variables to pass to the container. Defaults to None.
+        healthcheck (dict, optional): The stored healthcheck config, or None for no healthcheck.
 
     Returns:
         str: The id of the created container.
@@ -308,7 +329,9 @@ def spawn_service_container(
             DeviceRequest(device_ids=[str(gpu.uuid)], capabilities=[["gpu", "nvidia", "compute"]]) for gpu in devices
         ]
 
-    policy = {"MaximumRetryCount": 3, "Name": "on-failure"}
+    # no restart_policy: the reconciler owns restarts. a docker-level on-failure policy would
+    # restart the container behind its back, showing up as `restarting` (-> BOOTING) and silently
+    # multiplying the crash budget by the policy's retry count.
     container = client.containers.run(
         detach=True,
         remove=False,
@@ -318,7 +341,7 @@ def spawn_service_container(
         network=worker_network,
         volumes=volumes,
         environment=environment,
-        restart_policy=policy,  # type: ignore
+        healthcheck=docker_healthcheck(healthcheck),  # type: ignore
         runtime=runtime,
         device_requests=gpus,
         nano_cpus=int(resources.cpu_count * 1e9),
@@ -398,6 +421,7 @@ def create_service_entry(
     service_resources: ServiceCreateResources,
     service_environment: dict,
     model_instances: list[Model],
+    service_healthcheck: ServiceHealthcheck | None = None,
 ) -> Service:
     """
     Creates a new service entry in the database.
@@ -411,6 +435,7 @@ def create_service_entry(
         service_resources (ServiceResources): The resources allocated to the service.
         service_environment (dict): The environment variables for the service.
         model_instances (list): The list of model instances associated with the service.
+        service_healthcheck (ServiceHealthcheck, optional): The container healthcheck, if any.
 
     Returns:
         Service: The created service entry.
@@ -430,6 +455,7 @@ def create_service_entry(
         mem_size=service_resources.mem_size,
         shm_size=service_resources.shm_size,
         environment_variables=service_environment,
+        healthcheck=service_healthcheck.model_dump() if service_healthcheck else None,
     )
     service.resources = resources
 
@@ -474,6 +500,7 @@ def create_service(
     service_priority: int,
     model_infos: list[str],
     service_api_keys: list[str] | None = None,
+    service_healthcheck: ServiceHealthcheck | None = None,
 ) -> Service:
     """Declaratively creates a service record; the reconciler spawns the container out of band.
 
@@ -493,6 +520,7 @@ def create_service(
         service_priority (int): The priority for the service.
         model_infos (list): The list of models to load.
         service_api_keys (list[str], optional): The list of API keys to use for the service.
+        service_healthcheck (ServiceHealthcheck, optional): The container healthcheck, if any.
 
     Returns:
         Service: The created service.
@@ -513,6 +541,7 @@ def create_service(
             service_resources=service_resources,
             service_environment=service_environment,
             model_instances=model_instances,
+            service_healthcheck=service_healthcheck,
         )
         create_device_allocations(
             db=db,
@@ -540,7 +569,7 @@ def create_service(
 
 
 def delete_service(db: Session, traefik: TraefikConfigManager, service_id: int) -> None:
-    """Soft-deletes a service (Option A): DB record plus synchronous Traefik teardown.
+    """Soft-deletes a service: DB record plus synchronous Traefik teardown.
 
     Removes the Traefik config now (symmetric with create writing it synchronously), stamps
     deleted_at, and marks the service RETIRED. Capacity is released automatically because
@@ -628,6 +657,7 @@ def recreate_service_container(
             ),
             devices=device_objs,
             environment=res.environment_variables or {},
+            healthcheck=res.healthcheck,
         )
 
         service.container_id = str(container_id)
@@ -691,6 +721,9 @@ def update_service(
 
         if update_body.environment is not None:
             service.resources.environment_variables = update_body.environment
+
+        if update_body.healthcheck is not None:
+            service.resources.healthcheck = update_body.healthcheck.model_dump()
 
         if update_body.models is not None:
             new_model_instances = [get_single_model(db, name) for name in update_body.models]

--- a/src/triton_serve/api/services/domain.py
+++ b/src/triton_serve/api/services/domain.py
@@ -118,29 +118,6 @@ def get_service_by_id(db: Session, service_id: int) -> Service | None:
     return db.get(Service, ident=service_id)
 
 
-def get_service_by_name(db: Session, service_name: str) -> Service:
-    """Returns a specific non-deleted service by name. Read-only, no Docker call.
-
-    Args:
-        db (Session): The database session.
-        service_name (str): The name of the service.
-
-    Returns:
-        Service: The requested service.
-    """
-    service = (
-        db.query(Service)
-        .filter(
-            Service.service_name == service_name,
-            Service.deleted_at.is_(None),
-        )
-        .first()
-    )
-    if service is None:
-        raise HTTPException(status_code=404, detail=f"No active service named '{service_name}'")
-    return service
-
-
 def get_service_record_by_name(db: Session, service_name: str) -> Service | None:
     """Pure DB lookup for the status projection hook. No Docker call."""
     return db.query(Service).filter(Service.service_name == service_name, Service.deleted_at.is_(None)).one_or_none()
@@ -625,7 +602,7 @@ def recreate_service_container(
                 client.containers.get(service.container_id).remove(force=True)
             except NotFound:
                 pass
-            service.container_id = None  # type: ignore
+            service.container_id = None
 
         # a stale/foreign container may still hold the name under a different id (e.g. dirty
         # docker after a host reboot); clear it by name so the spawn below cannot 409.

--- a/src/triton_serve/api/services/execute.py
+++ b/src/triton_serve/api/services/execute.py
@@ -9,7 +9,7 @@ from triton_serve.api.services.reconcile import Action, Decision
 from triton_serve.config.schema import AppSettings
 from triton_serve.database.model import RuntimeStatus, Service
 
-LOG = logging.getLogger("uvicorn")
+LOG = logging.getLogger(__name__)
 
 
 def _recreate(db: Session, client: DockerClient, service: Service, settings: AppSettings) -> None:
@@ -45,6 +45,13 @@ def execute(
     """Apply a Decision's Action to Docker, then persist the projected runtime_status.
 
     The only place reconciliation Actions become Docker side effects.
+
+    Args:
+        db (Session): The database session.
+        client (DockerClient): The docker client.
+        service (Service): The service the decision was taken for.
+        decision (Decision): The action to apply and the status to project.
+        settings (AppSettings): The application settings.
     """
     action = decision.action
     try:
@@ -56,9 +63,10 @@ def execute(
                 if (c := get_container_by_name(client, service.service_name)) is not None:
                     c.start()
                 else:
-                    _recreate(db, client, service, settings)  # the outage fix: heal a vanished container
+                    _recreate(db, client, service, settings)
             case Action.RECREATE | Action.PULL:
-                # docker run pulls a missing image implicitly; PULL and RECREATE share the path
+                # PULL and RECREATE share the path: recreate resolves the image through
+                # get_service_image, which falls back to images.pull when it is not present locally
                 _recreate(db, client, service, settings)
             case Action.STOP:
                 if (c := get_container_by_name(client, service.service_name)) is not None:
@@ -72,7 +80,9 @@ def execute(
                 # domain.delete_service; nothing is left to do out of band
                 pass
             case Action.MARK_FAILED:
-                LOG.warning("Service %s exhausted restart budget -> FAILED", service.service_id)
+                # decide() returns MARK_FAILED on every tick a failed service is still wanted
+                if service.runtime_status != RuntimeStatus.FAILED:
+                    LOG.warning("Service %s exhausted restart budget -> FAILED", service.service_id)
     except Exception:
         LOG.exception("Action %s failed for service %s", action, service.service_id)
         db.rollback()

--- a/src/triton_serve/api/services/execute.py
+++ b/src/triton_serve/api/services/execute.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime, timezone
 
 from docker import DockerClient
-from docker.errors import NotFound
 from sqlalchemy.orm import Session
 
 from triton_serve.api.services.domain import get_container_by_name, recreate_service_container
@@ -15,6 +14,25 @@ LOG = logging.getLogger("uvicorn")
 
 def _recreate(db: Session, client: DockerClient, service: Service, settings: AppSettings) -> None:
     recreate_service_container(db, client, service, settings.service_network, settings.service_volume)
+
+
+def _spend_attempt(service: Service) -> None:
+    service.restart_attempts += 1
+    service.last_attempt_at = datetime.now(timezone.utc)
+
+
+def _maybe_reset_budget(service: Service, cooldown: int) -> None:
+    """Return the crash budget once a recovered service has stayed READY past the cooldown.
+
+    last_attempt_at marks the last recovery attempt; a READY observation never stamps it, so a
+    READY service whose last attempt is older than the cooldown has been stably up and earns its
+    budget back. FAILED never reaches READY, so this can never revive a terminally failed service.
+    """
+    if service.restart_attempts and service.last_attempt_at is not None:
+        elapsed = (datetime.now(timezone.utc) - service.last_attempt_at).total_seconds()
+        if elapsed > cooldown:
+            service.restart_attempts = 0
+            service.last_attempt_at = None
 
 
 def execute(
@@ -34,9 +52,10 @@ def execute(
             case Action.NONE:
                 pass
             case Action.START:
-                try:
-                    client.containers.get(service.container_id).start()
-                except NotFound:
+                # resolve by name, not the (possibly stale) stored id; recreate if it vanished
+                if (c := get_container_by_name(client, service.service_name)) is not None:
+                    c.start()
+                else:
                     _recreate(db, client, service, settings)  # the outage fix: heal a vanished container
             case Action.RECREATE | Action.PULL:
                 # docker run pulls a missing image implicitly; PULL and RECREATE share the path
@@ -47,7 +66,7 @@ def execute(
             case Action.REMOVE:
                 if (c := get_container_by_name(client, service.service_name)) is not None:
                     c.remove(force=True)
-                service.container_id = None  # type: ignore
+                service.container_id = None
             case Action.FINALIZE:
                 # terminal no-op: traefik config + allocation are torn down synchronously by
                 # domain.delete_service; nothing is left to do out of band
@@ -60,16 +79,16 @@ def execute(
         # a budgeted action (recreate/pull) that raised must still spend the budget, or a broken
         # image would retry forever; RECOVERING makes the next tick honor the backoff gate
         if decision.increment_attempt:
-            service.restart_attempts += 1
-            service.last_attempt_at = datetime.now(timezone.utc)
+            _spend_attempt(service)
             service.runtime_status = RuntimeStatus.RECOVERING
             db.commit()
             db.refresh(service)
         return
 
     if decision.increment_attempt:
-        service.restart_attempts += 1
-        service.last_attempt_at = datetime.now(timezone.utc)
+        _spend_attempt(service)
+    elif decision.status == RuntimeStatus.READY:
+        _maybe_reset_budget(service, settings.service_restart_cooldown)
     service.runtime_status = decision.status
     db.commit()
     db.refresh(service)

--- a/src/triton_serve/api/services/execute.py
+++ b/src/triton_serve/api/services/execute.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import datetime, timezone
+
+from docker import DockerClient
+from docker.errors import NotFound
+from sqlalchemy.orm import Session
+
+from triton_serve.api.services.domain import get_container_by_name, recreate_service_container
+from triton_serve.api.services.reconcile import Action, Decision
+from triton_serve.config import get_traefik
+from triton_serve.config.schema import AppSettings
+from triton_serve.database.model import Service
+
+LOG = logging.getLogger("uvicorn")
+
+
+def _recreate(db: Session, client: DockerClient, service: Service, settings: AppSettings) -> None:
+    recreate_service_container(db, client, service, settings.service_network, settings.service_volume)
+
+
+def execute(
+    db: Session,
+    client: DockerClient,
+    service: Service,
+    decision: Decision,
+    settings: AppSettings,
+) -> None:
+    """Apply a Decision's Action to Docker, then persist the projected runtime_status.
+
+    The only place reconciliation Actions become Docker side effects.
+    """
+    action = decision.action
+    try:
+        match action:
+            case Action.NONE:
+                pass
+            case Action.START:
+                try:
+                    client.containers.get(service.container_id).start()
+                except NotFound:
+                    _recreate(db, client, service, settings)  # the outage fix: heal a vanished container
+            case Action.RECREATE | Action.PULL:
+                # docker run pulls a missing image implicitly; PULL and RECREATE share the path
+                _recreate(db, client, service, settings)
+            case Action.STOP:
+                if (c := get_container_by_name(client, service.service_name)) is not None:
+                    c.stop()
+            case Action.REMOVE:
+                if (c := get_container_by_name(client, service.service_name)) is not None:
+                    c.remove(force=True)
+                service.container_id = None  # type: ignore
+            case Action.FINALIZE:
+                get_traefik().delete(service_name=service.service_name)
+                # allocation release + deleted_at handled by the existing delete path; see domain.delete_service
+            case Action.MARK_FAILED:
+                LOG.warning("Service %s exhausted restart budget -> FAILED", service.service_id)
+    except Exception:
+        LOG.exception("Action %s failed for service %s; leaving status for next tick", action, service.service_id)
+        db.rollback()
+        return
+
+    if decision.increment_attempt:
+        service.restart_attempts += 1
+        service.last_attempt_at = datetime.now(timezone.utc)
+    service.runtime_status = decision.status
+    db.commit()
+    db.refresh(service)

--- a/src/triton_serve/api/services/execute.py
+++ b/src/triton_serve/api/services/execute.py
@@ -7,9 +7,8 @@ from sqlalchemy.orm import Session
 
 from triton_serve.api.services.domain import get_container_by_name, recreate_service_container
 from triton_serve.api.services.reconcile import Action, Decision
-from triton_serve.config import get_traefik
 from triton_serve.config.schema import AppSettings
-from triton_serve.database.model import Service
+from triton_serve.database.model import RuntimeStatus, Service
 
 LOG = logging.getLogger("uvicorn")
 
@@ -50,13 +49,22 @@ def execute(
                     c.remove(force=True)
                 service.container_id = None  # type: ignore
             case Action.FINALIZE:
-                get_traefik().delete(service_name=service.service_name)
-                # allocation release + deleted_at handled by the existing delete path; see domain.delete_service
+                # terminal no-op: traefik config + allocation are torn down synchronously by
+                # domain.delete_service; nothing is left to do out of band
+                pass
             case Action.MARK_FAILED:
                 LOG.warning("Service %s exhausted restart budget -> FAILED", service.service_id)
     except Exception:
-        LOG.exception("Action %s failed for service %s; leaving status for next tick", action, service.service_id)
+        LOG.exception("Action %s failed for service %s", action, service.service_id)
         db.rollback()
+        # a budgeted action (recreate/pull) that raised must still spend the budget, or a broken
+        # image would retry forever; RECOVERING makes the next tick honor the backoff gate
+        if decision.increment_attempt:
+            service.restart_attempts += 1
+            service.last_attempt_at = datetime.now(timezone.utc)
+            service.runtime_status = RuntimeStatus.RECOVERING
+            db.commit()
+            db.refresh(service)
         return
 
     if decision.increment_attempt:

--- a/src/triton_serve/api/services/observe.py
+++ b/src/triton_serve/api/services/observe.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+
+from docker import DockerClient
+from docker.errors import ImageNotFound, NotFound
+
+from triton_serve.api.services.reconcile import ObservedFact
+from triton_serve.database.model import Service
+
+
+def _image_present(client: DockerClient, image_ref: str) -> bool:
+    try:
+        client.images.get(image_ref)
+        return True
+    except ImageNotFound:
+        return False
+
+
+def _running_fact(container, boot_grace_seconds: int) -> ObservedFact:
+    state = container.attrs.get("State", {})
+    health = (state.get("Health") or {}).get("Status")
+    if health == "healthy":
+        return ObservedFact.RUNNING
+    if health in ("starting", "unhealthy"):
+        return ObservedFact.BOOTING
+    # no healthcheck: treat as booting until it has been up past the boot grace
+    started_raw = state.get("StartedAt")
+    try:
+        started = datetime.fromisoformat(started_raw)
+    except TypeError, ValueError:
+        return ObservedFact.RUNNING
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    uptime = (datetime.now(timezone.utc) - started).total_seconds()
+    return ObservedFact.RUNNING if uptime >= boot_grace_seconds else ObservedFact.BOOTING
+
+
+def observe(client: DockerClient, service: Service, boot_grace_seconds: int) -> ObservedFact:
+    """Derive the current observed fact for a service from the Docker daemon (read-only)."""
+    try:
+        container = client.containers.get(service.service_name)
+    except NotFound:
+        return ObservedFact.ABSENT if _image_present(client, service.service_image) else ObservedFact.IMAGE_MISSING
+
+    if container.status == "running":
+        return _running_fact(container, boot_grace_seconds)
+    if container.status in ("created", "restarting"):
+        return ObservedFact.BOOTING
+    exit_code = container.attrs.get("State", {}).get("ExitCode", 0)
+    return ObservedFact.EXITED_OK if exit_code == 0 else ObservedFact.CRASHED

--- a/src/triton_serve/api/services/observe.py
+++ b/src/triton_serve/api/services/observe.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from docker import DockerClient
 from docker.errors import ImageNotFound, NotFound
+from docker.models.containers import Container
 
 from triton_serve.api.services.reconcile import ObservedFact
 from triton_serve.database.model import Service
@@ -15,22 +16,34 @@ def _image_present(client: DockerClient, image_ref: str) -> bool:
         return False
 
 
-def _running_fact(container, boot_grace_seconds: int) -> ObservedFact:
+def _uptime_seconds(state: dict) -> float | None:
+    """Seconds since the container started, or None if the timestamp is missing/unparseable."""
+    started_raw = state.get("StartedAt")
+    if not isinstance(started_raw, str):
+        return None
+    try:
+        started = datetime.fromisoformat(started_raw)
+    except ValueError:
+        return None
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - started).total_seconds()
+
+
+def _running_fact(container: Container, boot_grace_seconds: int) -> ObservedFact:
     state = container.attrs.get("State", {})
     health = (state.get("Health") or {}).get("Status")
     if health == "healthy":
         return ObservedFact.RUNNING
+    uptime = _uptime_seconds(state)
     if health in ("starting", "unhealthy"):
-        return ObservedFact.BOOTING
+        # still coming up within the grace window; a healthcheck still failing past it is a crash
+        if uptime is None:
+            return ObservedFact.BOOTING
+        return ObservedFact.BOOTING if uptime < boot_grace_seconds else ObservedFact.CRASHED
     # no healthcheck: treat as booting until it has been up past the boot grace
-    started_raw = state.get("StartedAt")
-    try:
-        started = datetime.fromisoformat(started_raw)
-    except TypeError, ValueError:
+    if uptime is None:
         return ObservedFact.RUNNING
-    if started.tzinfo is None:
-        started = started.replace(tzinfo=timezone.utc)
-    uptime = (datetime.now(timezone.utc) - started).total_seconds()
     return ObservedFact.RUNNING if uptime >= boot_grace_seconds else ObservedFact.BOOTING
 
 

--- a/src/triton_serve/api/services/observe.py
+++ b/src/triton_serve/api/services/observe.py
@@ -4,7 +4,7 @@ from docker import DockerClient
 from docker.errors import ImageNotFound, NotFound
 from docker.models.containers import Container
 
-from triton_serve.api.services.reconcile import ObservedFact
+from triton_serve.api.services.reconcile import ObservedState
 from triton_serve.database.model import Service
 
 
@@ -30,33 +30,48 @@ def _uptime_seconds(state: dict) -> float | None:
     return (datetime.now(timezone.utc) - started).total_seconds()
 
 
-def _running_fact(container: Container, boot_grace_seconds: int) -> ObservedFact:
+def _running_fact(container: Container, boot_grace_seconds: int) -> ObservedState:
+    """Health verdict for a running container. Docker owns it whenever a healthcheck is configured.
+
+    Docker holds `starting` for the whole start period and only flips to `unhealthy` after the
+    configured retries, so a second timer here could only ever fire early on a container docker
+    still considers healthy. The boot grace is left to the no-healthcheck case, which has no
+    other signal that the container has settled.
+    """
     state = container.attrs.get("State", {})
-    health = (state.get("Health") or {}).get("Status")
-    if health == "healthy":
-        return ObservedFact.RUNNING
-    uptime = _uptime_seconds(state)
-    if health in ("starting", "unhealthy"):
-        # still coming up within the grace window; a healthcheck still failing past it is a crash
-        if uptime is None:
-            return ObservedFact.BOOTING
-        return ObservedFact.BOOTING if uptime < boot_grace_seconds else ObservedFact.CRASHED
-    # no healthcheck: treat as booting until it has been up past the boot grace
-    if uptime is None:
-        return ObservedFact.RUNNING
-    return ObservedFact.RUNNING if uptime >= boot_grace_seconds else ObservedFact.BOOTING
+    match (state.get("Health") or {}).get("Status"):
+        case "healthy":
+            return ObservedState.RUNNING
+        case "unhealthy":
+            return ObservedState.CRASHED
+        case "starting":
+            return ObservedState.BOOTING
+        case _:
+            uptime = _uptime_seconds(state)
+            if uptime is None:
+                return ObservedState.RUNNING
+            return ObservedState.RUNNING if uptime >= boot_grace_seconds else ObservedState.BOOTING
 
 
-def observe(client: DockerClient, service: Service, boot_grace_seconds: int) -> ObservedFact:
-    """Derive the current observed fact for a service from the Docker daemon (read-only)."""
+def observe(client: DockerClient, service: Service, boot_grace_seconds: int) -> ObservedState:
+    """Derive the current observed fact for a service from the Docker daemon (read-only).
+
+    Args:
+        client (DockerClient): The docker client.
+        service (Service): The service to observe.
+        boot_grace_seconds (int): How long a container without a healthcheck stays BOOTING.
+
+    Returns:
+        ObservedState: The fact the reconciler decides on.
+    """
     try:
         container = client.containers.get(service.service_name)
     except NotFound:
-        return ObservedFact.ABSENT if _image_present(client, service.service_image) else ObservedFact.IMAGE_MISSING
+        return ObservedState.ABSENT if _image_present(client, service.service_image) else ObservedState.IMAGE_MISSING
 
     if container.status == "running":
         return _running_fact(container, boot_grace_seconds)
     if container.status in ("created", "restarting"):
-        return ObservedFact.BOOTING
+        return ObservedState.BOOTING
     exit_code = container.attrs.get("State", {}).get("ExitCode", 0)
-    return ObservedFact.EXITED_OK if exit_code == 0 else ObservedFact.CRASHED
+    return ObservedState.EXITED_OK if exit_code == 0 else ObservedState.CRASHED

--- a/src/triton_serve/api/services/reconcile.py
+++ b/src/triton_serve/api/services/reconcile.py
@@ -1,0 +1,95 @@
+import enum
+from dataclasses import dataclass
+
+from triton_serve.database.model import DesiredState, RuntimeStatus
+
+
+class ObservedFact(enum.Enum):
+    RUNNING = "running"  # container up, health passing
+    BOOTING = "booting"  # up, health not yet passing, within boot grace
+    EXITED_OK = "exited_ok"  # exited, code 0
+    CRASHED = "crashed"  # exited, code != 0
+    ABSENT = "absent"  # no container bound to the service (vanished / stale id)
+    IMAGE_MISSING = "image_missing"
+
+
+class Action(enum.Enum):
+    NONE = "none"
+    START = "start"  # start the existing stopped container (recreate on failure)
+    RECREATE = "recreate"  # recreate by service name
+    STOP = "stop"  # graceful stop
+    REMOVE = "remove"  # stop + remove the container
+    PULL = "pull"  # pull the image, then recreate
+    FINALIZE = "finalize"  # remove traefik config, release allocation, tombstone
+    MARK_FAILED = "mark_failed"
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: Action
+    status: RuntimeStatus
+    increment_attempt: bool = False
+
+
+def _available(observed: ObservedFact, target: int, attempts: int, max_attempts: int) -> Decision:
+    exhausted = attempts >= max_attempts
+    if target == 0:
+        # scaled to zero; only surface FAILED if a crash already spent the budget
+        if observed in (ObservedFact.RUNNING, ObservedFact.BOOTING):
+            return Decision(Action.STOP, RuntimeStatus.IDLE)
+        if observed is ObservedFact.CRASHED and exhausted:
+            return Decision(Action.NONE, RuntimeStatus.FAILED)
+        return Decision(Action.NONE, RuntimeStatus.IDLE)
+
+    # target == 1: drive toward serving
+    match observed:
+        case ObservedFact.RUNNING:
+            return Decision(Action.NONE, RuntimeStatus.READY)
+        case ObservedFact.BOOTING:
+            return Decision(Action.NONE, RuntimeStatus.WARMING)
+        case ObservedFact.EXITED_OK:
+            return Decision(Action.START, RuntimeStatus.WARMING)
+        case ObservedFact.ABSENT:
+            return Decision(Action.RECREATE, RuntimeStatus.WARMING)
+        case ObservedFact.CRASHED:
+            if exhausted:
+                return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
+            return Decision(Action.RECREATE, RuntimeStatus.RECOVERING, increment_attempt=True)
+        case ObservedFact.IMAGE_MISSING:
+            if exhausted:
+                return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
+            return Decision(Action.PULL, RuntimeStatus.WARMING, increment_attempt=True)
+    raise AssertionError(f"unreachable observed={observed}")  # pragma: no cover
+
+
+def _suspended(observed: ObservedFact) -> Decision:
+    if observed in (ObservedFact.RUNNING, ObservedFact.BOOTING):
+        return Decision(Action.STOP, RuntimeStatus.SUSPENDED)
+    return Decision(Action.NONE, RuntimeStatus.SUSPENDED)
+
+
+def _retired(observed: ObservedFact) -> Decision:
+    if observed in (ObservedFact.RUNNING, ObservedFact.BOOTING, ObservedFact.EXITED_OK, ObservedFact.CRASHED):
+        return Decision(Action.REMOVE, RuntimeStatus.RETIRED)
+    return Decision(Action.FINALIZE, RuntimeStatus.RETIRED)
+
+
+def decide(
+    desired: DesiredState,
+    observed: ObservedFact,
+    replica_target: int,
+    attempts: int,
+    max_attempts: int,
+) -> Decision:
+    """Pure reconciliation matrix: maps (intent, observed reality, scale, budget) to one action.
+
+    replica_target is 0/1 and is only ever 1 under AVAILABLE (the autoscaler's decision).
+    """
+    match desired:
+        case DesiredState.AVAILABLE:
+            return _available(observed, replica_target, attempts, max_attempts)
+        case DesiredState.SUSPENDED:
+            return _suspended(observed)
+        case DesiredState.RETIRED:
+            return _retired(observed)
+    raise AssertionError(f"unreachable desired={desired}")  # pragma: no cover

--- a/src/triton_serve/api/services/reconcile.py
+++ b/src/triton_serve/api/services/reconcile.py
@@ -41,15 +41,20 @@ def _available(observed: ObservedFact, target: int, attempts: int, max_attempts:
             return Decision(Action.NONE, RuntimeStatus.FAILED)
         return Decision(Action.NONE, RuntimeStatus.IDLE)
 
-    # target == 1: drive toward serving
+    # target == 1: drive toward serving. once the budget is spent every bring-up refuses, so
+    # FAILED stays terminal (even if the dead container is later removed) until /retry resets it
     match observed:
         case ObservedFact.RUNNING:
             return Decision(Action.NONE, RuntimeStatus.READY)
         case ObservedFact.BOOTING:
             return Decision(Action.NONE, RuntimeStatus.WARMING)
         case ObservedFact.EXITED_OK:
+            if exhausted:
+                return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
             return Decision(Action.START, RuntimeStatus.WARMING)
         case ObservedFact.ABSENT:
+            if exhausted:
+                return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
             return Decision(Action.RECREATE, RuntimeStatus.WARMING)
         case ObservedFact.CRASHED:
             if exhausted:

--- a/src/triton_serve/api/services/reconcile.py
+++ b/src/triton_serve/api/services/reconcile.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from triton_serve.database.model import DesiredState, RuntimeStatus
 
 
-class ObservedFact(enum.Enum):
+class ObservedState(enum.Enum):
     RUNNING = "running"  # container up, health passing
     BOOTING = "booting"  # up, health not yet passing, within boot grace
     EXITED_OK = "exited_ok"  # exited, code 0
@@ -31,64 +31,72 @@ class Decision:
     increment_attempt: bool = False
 
 
-def _available(observed: ObservedFact, target: int, attempts: int, max_attempts: int) -> Decision:
+def _available(observed: ObservedState, target: int, attempts: int, max_attempts: int) -> Decision:
     exhausted = attempts >= max_attempts
     if target == 0:
         # scaled to zero; only surface FAILED if a crash already spent the budget
-        if observed in (ObservedFact.RUNNING, ObservedFact.BOOTING):
+        if observed in (ObservedState.RUNNING, ObservedState.BOOTING):
             return Decision(Action.STOP, RuntimeStatus.IDLE)
-        if observed is ObservedFact.CRASHED and exhausted:
+        if observed is ObservedState.CRASHED and exhausted:
             return Decision(Action.NONE, RuntimeStatus.FAILED)
         return Decision(Action.NONE, RuntimeStatus.IDLE)
 
     # target == 1: drive toward serving. once the budget is spent every bring-up refuses, so
     # FAILED stays terminal (even if the dead container is later removed) until /retry resets it
     match observed:
-        case ObservedFact.RUNNING:
+        case ObservedState.RUNNING:
             return Decision(Action.NONE, RuntimeStatus.READY)
-        case ObservedFact.BOOTING:
+        case ObservedState.BOOTING:
             return Decision(Action.NONE, RuntimeStatus.WARMING)
-        case ObservedFact.EXITED_OK:
+        case ObservedState.EXITED_OK:
             if exhausted:
                 return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
             return Decision(Action.START, RuntimeStatus.WARMING)
-        case ObservedFact.ABSENT:
+        case ObservedState.ABSENT:
             if exhausted:
                 return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
             return Decision(Action.RECREATE, RuntimeStatus.WARMING)
-        case ObservedFact.CRASHED:
+        case ObservedState.CRASHED:
             if exhausted:
                 return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
             return Decision(Action.RECREATE, RuntimeStatus.RECOVERING, increment_attempt=True)
-        case ObservedFact.IMAGE_MISSING:
+        case ObservedState.IMAGE_MISSING:
             if exhausted:
                 return Decision(Action.MARK_FAILED, RuntimeStatus.FAILED)
             return Decision(Action.PULL, RuntimeStatus.WARMING, increment_attempt=True)
     raise AssertionError(f"unreachable observed={observed}")  # pragma: no cover
 
 
-def _suspended(observed: ObservedFact) -> Decision:
-    if observed in (ObservedFact.RUNNING, ObservedFact.BOOTING):
+def _suspended(observed: ObservedState) -> Decision:
+    if observed in (ObservedState.RUNNING, ObservedState.BOOTING):
         return Decision(Action.STOP, RuntimeStatus.SUSPENDED)
     return Decision(Action.NONE, RuntimeStatus.SUSPENDED)
 
 
-def _retired(observed: ObservedFact) -> Decision:
-    if observed in (ObservedFact.RUNNING, ObservedFact.BOOTING, ObservedFact.EXITED_OK, ObservedFact.CRASHED):
+def _retired(observed: ObservedState) -> Decision:
+    if observed in (ObservedState.RUNNING, ObservedState.BOOTING, ObservedState.EXITED_OK, ObservedState.CRASHED):
         return Decision(Action.REMOVE, RuntimeStatus.RETIRED)
     return Decision(Action.FINALIZE, RuntimeStatus.RETIRED)
 
 
 def decide(
     desired: DesiredState,
-    observed: ObservedFact,
+    observed: ObservedState,
     replica_target: int,
     attempts: int,
     max_attempts: int,
 ) -> Decision:
     """Pure reconciliation matrix: maps (intent, observed reality, scale, budget) to one action.
 
-    replica_target is 0/1 and is only ever 1 under AVAILABLE (the autoscaler's decision).
+    Args:
+        desired (DesiredState): The operator intent recorded on the service.
+        observed (ObservedState): The fact observed on the docker daemon.
+        replica_target (int): 0 or 1, and only ever 1 under AVAILABLE (the autoscaler's decision).
+        attempts (int): Recovery attempts already spent.
+        max_attempts (int): The crash budget.
+
+    Returns:
+        Decision: The action to apply and the runtime status to project.
     """
     match desired:
         case DesiredState.AVAILABLE:

--- a/src/triton_serve/config/schema.py
+++ b/src/triton_serve/config/schema.py
@@ -37,7 +37,8 @@ class AppSettings(BaseSettings):
     service_volume: str = "triton-serve_models"
     service_prefix: str = ""
     service_max_restart_attempts: int = 3
-    service_restart_cooldown: int = 600  # seconds
+    service_restart_cooldown: int = 600  # seconds; also the READY window that earns the budget back
+    service_restart_backoff_base: int = 10  # seconds; base of the exponential retry backoff
 
     # database
     database_user: str
@@ -47,7 +48,7 @@ class AppSettings(BaseSettings):
     database_name: str = "serve_db"
 
     # worker params
-    sentinel_poll_interval: int = 60
+    sentinel_poll_interval: int = 10  # reconcile tick; the loop is a cheap DB read + docker inspect
     docker_timeout: int = 10  # seconds; reconciler Docker client, fail fast not 60s
     service_boot_grace: int = 30  # seconds a no-healthcheck container is BOOTING
     backend_host: str

--- a/src/triton_serve/config/schema.py
+++ b/src/triton_serve/config/schema.py
@@ -48,6 +48,8 @@ class AppSettings(BaseSettings):
 
     # worker params
     sentinel_poll_interval: int = 60
+    docker_timeout: int = 10  # seconds; reconciler Docker client, fail fast not 60s
+    service_boot_grace: int = 30  # seconds a no-healthcheck container is BOOTING
     backend_host: str
     backend_port: int
 

--- a/src/triton_serve/database/manage.py
+++ b/src/triton_serve/database/manage.py
@@ -25,10 +25,11 @@ class DatabaseManager:
         self._sessionmaker = None
 
     @contextlib.contextmanager
-    def connect(self):
+    def connect(self, isolation_level: str | None = None):
         if self._engine is None:
             raise Exception("DatabaseSessionManager is not initialized")
-        with self._engine.begin() as connection:
+        engine = self._engine.execution_options(isolation_level=isolation_level) if isolation_level else self._engine
+        with engine.begin() as connection:
             try:
                 yield connection
             except Exception:

--- a/src/triton_serve/database/model.py
+++ b/src/triton_serve/database/model.py
@@ -33,15 +33,6 @@ class ModelType(enum.Enum):
     ENSEMBLE = "ensemble"
 
 
-class ServiceStatus(enum.Enum):
-    STARTING = "starting"
-    ACTIVE = "active"
-    ERROR = "error"
-    STOPPED = "stopped"
-    DELETED = "deleted"
-    MISSING = "missing"
-
-
 class DesiredState(enum.Enum):
     AVAILABLE = "available"  # serve; reconciler may scale to 0 on idle and wakes on request
     SUSPENDED = "suspended"  # operator forced off; no auto-wake
@@ -153,7 +144,6 @@ class Service(Base):
     service_name: Mapped[str] = mapped_column(nullable=False)
     service_image: Mapped[str] = mapped_column(nullable=False)
     container_id: Mapped[str] = mapped_column(nullable=True)
-    container_status: Mapped[ServiceStatus] = mapped_column(nullable=False, default=ServiceStatus.STARTING)
     # values_callable: the desiredstate/runtimestatus postgres enums store the lowercase .value
     # labels (see the lifecycle_redesign_expand migration), not the Python member names.
     desired_state: Mapped[DesiredState] = mapped_column(

--- a/src/triton_serve/database/model.py
+++ b/src/triton_serve/database/model.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     DateTime,
+    Enum,
     ForeignKey,
     Index,
     PrimaryKeyConstraint,
@@ -39,6 +40,22 @@ class ServiceStatus(enum.Enum):
     STOPPED = "stopped"
     DELETED = "deleted"
     MISSING = "missing"
+
+
+class DesiredState(enum.Enum):
+    AVAILABLE = "available"  # serve; reconciler may scale to 0 on idle and wakes on request
+    SUSPENDED = "suspended"  # operator forced off; no auto-wake
+    RETIRED = "retired"  # deleted; allocation released, traefik config removed
+
+
+class RuntimeStatus(enum.Enum):
+    READY = "ready"
+    WARMING = "warming"
+    IDLE = "idle"
+    RECOVERING = "recovering"
+    FAILED = "failed"
+    SUSPENDED = "suspended"
+    RETIRED = "retired"
 
 
 class KeyType(enum.Enum):
@@ -137,6 +154,18 @@ class Service(Base):
     service_image: Mapped[str] = mapped_column(nullable=False)
     container_id: Mapped[str] = mapped_column(nullable=True)
     container_status: Mapped[ServiceStatus] = mapped_column(nullable=False, default=ServiceStatus.STARTING)
+    # values_callable: the desiredstate/runtimestatus postgres enums store the lowercase .value
+    # labels (see the lifecycle_redesign_expand migration), not the Python member names.
+    desired_state: Mapped[DesiredState] = mapped_column(
+        Enum(DesiredState, name="desiredstate", values_callable=lambda enum_cls: [e.value for e in enum_cls]),
+        nullable=False,
+        default=DesiredState.AVAILABLE,
+    )
+    runtime_status: Mapped[RuntimeStatus] = mapped_column(
+        Enum(RuntimeStatus, name="runtimestatus", values_callable=lambda enum_cls: [e.value for e in enum_cls]),
+        nullable=False,
+        default=RuntimeStatus.WARMING,
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     deleted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
     last_active_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/src/triton_serve/database/model.py
+++ b/src/triton_serve/database/model.py
@@ -143,18 +143,20 @@ class Service(Base):
     service_id: Mapped[int] = mapped_column(primary_key=True)
     service_name: Mapped[str] = mapped_column(nullable=False)
     service_image: Mapped[str] = mapped_column(nullable=False)
-    container_id: Mapped[str] = mapped_column(nullable=True)
+    container_id: Mapped[str | None] = mapped_column(default=None)
     # values_callable: the desiredstate/runtimestatus postgres enums store the lowercase .value
     # labels (see the lifecycle_redesign_expand migration), not the Python member names.
     desired_state: Mapped[DesiredState] = mapped_column(
         Enum(DesiredState, name="desiredstate", values_callable=lambda enum_cls: [e.value for e in enum_cls]),
         nullable=False,
         default=DesiredState.AVAILABLE,
+        server_default=DesiredState.AVAILABLE.value,
     )
     runtime_status: Mapped[RuntimeStatus] = mapped_column(
         Enum(RuntimeStatus, name="runtimestatus", values_callable=lambda enum_cls: [e.value for e in enum_cls]),
         nullable=False,
         default=RuntimeStatus.WARMING,
+        server_default=RuntimeStatus.WARMING.value,
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     deleted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True, default=None)

--- a/src/triton_serve/database/model.py
+++ b/src/triton_serve/database/model.py
@@ -185,6 +185,7 @@ class ServiceResources(Base):
     shm_size: Mapped[int] = mapped_column(nullable=False)
     mem_size: Mapped[int] = mapped_column(nullable=False)
     environment_variables: Mapped[dict] = mapped_column(JSONB, nullable=True)
+    healthcheck: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
     service: Mapped[Service] = relationship(back_populates="resources")
 
     __table_args__ = (

--- a/src/triton_serve/database/schema.py
+++ b/src/triton_serve/database/schema.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from triton_serve.database.model import DesiredState, KeyType, ModelType, RuntimeStatus, ServiceStatus
+from triton_serve.database.model import DesiredState, KeyType, ModelType, RuntimeStatus
 
 
 def timezone_aware_now():
@@ -95,7 +95,6 @@ class ServiceBaseSchema(BaseModel):
     service_name: str
     service_image: str
     container_id: str | None = None
-    container_status: ServiceStatus = ServiceStatus.STARTING
     created_at: datetime = Field(default_factory=timezone_aware_now)
     deleted_at: datetime | None = None
     inactivity_timeout: int = Field(default=3600, ge=0)
@@ -112,7 +111,7 @@ class ServiceInfoSchema(BaseModel):
     service_id: int
     service_name: str
     container_id: str | None = None
-    container_status: ServiceStatus
+    runtime_status: RuntimeStatus
 
 
 class ServiceCreateSchema(ServiceBaseSchema):
@@ -157,7 +156,7 @@ class ResourceUsageSchema(BaseModel):
 class DeviceServiceSchema(BaseModel):
     service_id: int
     service_name: str
-    container_status: ServiceStatus
+    runtime_status: RuntimeStatus
     allocation_percentage: float
 
 
@@ -195,7 +194,7 @@ class ServiceDeviceAllocationSchema(BaseModel):
 class ServiceAllocationSchema(BaseModel):
     service_id: int
     service_name: str
-    container_status: ServiceStatus
+    runtime_status: RuntimeStatus
     cpu_count: int
     mem_size: int
     devices: list[ServiceDeviceAllocationSchema]

--- a/src/triton_serve/database/schema.py
+++ b/src/triton_serve/database/schema.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from triton_serve.database.model import KeyType, ModelType, ServiceStatus
+from triton_serve.database.model import DesiredState, KeyType, ModelType, RuntimeStatus, ServiceStatus
 
 
 def timezone_aware_now():
@@ -122,6 +122,8 @@ class ServiceCreateSchema(ServiceBaseSchema):
 class ServiceSchema(ServiceBaseSchema):
     model_config = ConfigDict(from_attributes=True)
     service_id: int
+    desired_state: DesiredState
+    runtime_status: RuntimeStatus
 
 
 class APIKeyBaseSchema(BaseModel):

--- a/src/triton_serve/database/schema.py
+++ b/src/triton_serve/database/schema.py
@@ -84,6 +84,7 @@ class ServiceResourcesSchema(BaseModel):
     shm_size: int = Field(gt=0)
     mem_size: int = Field(gt=0)
     environment_variables: dict | None = None
+    healthcheck: dict | None = None
 
 
 class DeviceAllocationSchema(BaseModel):

--- a/src/triton_serve/extensions.py
+++ b/src/triton_serve/extensions.py
@@ -16,21 +16,6 @@ def get_db():
         yield session
 
 
-def docker_client() -> docker.DockerClient:  # type: ignore
-    """Yields a docker client API instance safely.
-
-    :return: docker client instance
-    :rtype: docker.DockerClient
-    :yield: docker client, useful to interact with the system
-    :rtype: Iterator[docker.DockerClient]
-    """
-    client = docker.from_env()
-    try:
-        yield client  # type: ignore
-    finally:
-        client.close()
-
-
 def get_reconciler_docker_client() -> docker.DockerClient:
     """Long-lived Docker client for the reconciler ONLY. Short timeout so a slow daemon
     fails fast instead of blocking. Request handlers must not call Docker — read the DB."""

--- a/src/triton_serve/extensions.py
+++ b/src/triton_serve/extensions.py
@@ -1,6 +1,9 @@
 import docker
 
+from triton_serve.config import get_settings
 from triton_serve.database import database_manager
+
+_reconciler_client: "docker.DockerClient | None" = None
 
 
 def get_db():
@@ -26,3 +29,13 @@ def docker_client() -> docker.DockerClient:  # type: ignore
         yield client  # type: ignore
     finally:
         client.close()
+
+
+def get_reconciler_docker_client() -> docker.DockerClient:
+    """Long-lived Docker client for the reconciler ONLY. Short timeout so a slow daemon
+    fails fast instead of blocking. Request handlers must not call Docker — read the DB."""
+    global _reconciler_client
+    if _reconciler_client is None:
+        settings = get_settings()
+        _reconciler_client = docker.from_env(timeout=settings.docker_timeout)
+    return _reconciler_client

--- a/src/triton_serve/tasks.py
+++ b/src/triton_serve/tasks.py
@@ -55,7 +55,7 @@ def update_service_status() -> None:
     client = get_reconciler_docker_client()
     now = datetime.now(tz=timezone.utc)
     with database_manager.session() as db:
-        services = db.query(Service).filter(Service.desired_state != DesiredState.RETIRED).all()
+        services = db.query(Service).filter(Service.runtime_status != RuntimeStatus.RETIRED).all()
         for service in services:
             try:
                 # reset the crash budget once the cooldown has elapsed since the last attempt

--- a/src/triton_serve/tasks.py
+++ b/src/triton_serve/tasks.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 from celery import Celery
+from celery.signals import worker_process_init, worker_process_shutdown
 from httpx import Client
 from sqlalchemy import text
 
@@ -26,11 +27,23 @@ app = Celery("serve-sentinel")
 app.config_from_object(Config)
 
 
+@worker_process_init.connect
+def init_worker_database(**_):
+    """The webserver's lifespan never runs here, so the worker owns its own engine.
+
+    Per forked child, not at import: the prefork parent's connections would be inherited by every
+    child and used concurrently on the same sockets.
+    """
+    database_manager.init(settings.database_url)
+
+
+@worker_process_shutdown.connect
+def close_worker_database(**_):
+    database_manager.close()
+
+
 @app.on_after_configure.connect  # type: ignore
 def setup_periodic_tasks(sender, **_):
-    """
-    Setup periodic tasks
-    """
     sender.add_periodic_task(
         settings.sentinel_poll_interval,
         update_service_status.s(),  # type: ignore
@@ -51,6 +64,7 @@ def _replica_target(service: Service, now: datetime) -> int:
 
 
 def _backoff_seconds(attempts: int, base: int, cap: int) -> int:
+    """How many seconds before retrying"""
     return min(base * (2 ** max(attempts - 1, 0)), cap)
 
 
@@ -58,11 +72,11 @@ def _backoff_seconds(attempts: int, base: int, cap: int) -> int:
 def update_service_status() -> None:
     """Reconcile every non-retired service: observe -> decide -> execute. Reconciler owns Docker."""
     client = get_reconciler_docker_client()
-    now = datetime.now(tz=timezone.utc)
     # single-flight across the whole pass: hold the advisory lock on a dedicated connection so it
     # survives the per-service commits below -- an ORM session releases its connection on each commit,
-    # which would strand the lock on a pooled connection and unlock a different one
-    with database_manager.connect() as lock_conn:
+    # which would strand the lock on a pooled connection and unlock a different one. autocommit keeps
+    # that connection from sitting idle-in-transaction, pinning a snapshot for the whole pass
+    with database_manager.connect(isolation_level="AUTOCOMMIT") as lock_conn:
         if not lock_conn.execute(text("SELECT pg_try_advisory_lock(:k)"), {"k": _RECONCILE_LOCK_KEY}).scalar():
             LOG.info("another reconcile pass holds the advisory lock; skipping this tick")
             return
@@ -71,6 +85,7 @@ def update_service_status() -> None:
                 services = db.query(Service).filter(Service.runtime_status != RuntimeStatus.RETIRED).all()
                 for service in services:
                     try:
+                        now = datetime.now(tz=timezone.utc)
                         # honor backoff: skip a service mid-retry still cooling down between attempts.
                         # RECOVERING is the status the executor persists after any spent attempt (crash
                         # recreate or image pull), so image-pull failures draw on the same crash budget
@@ -97,6 +112,16 @@ def update_service_status() -> None:
                             replica_target=target,
                             attempts=service.restart_attempts,
                             max_attempts=settings.service_max_restart_attempts,
+                        )
+                        LOG.debug(
+                            "reconcile %s: desired=%s target=%d observed=%s attempts=%d -> %s => %s",
+                            service.service_name,
+                            service.desired_state.value,
+                            target,
+                            observed.value,
+                            service.restart_attempts,
+                            decision.action.value,
+                            decision.status.value,
                         )
                         execute(db=db, client=client, service=service, decision=decision, settings=settings)
                     except Exception as e:

--- a/src/triton_serve/tasks.py
+++ b/src/triton_serve/tasks.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from celery import Celery
 from httpx import Client
+from sqlalchemy import text
 
 from triton_serve.api.services.execute import execute
 from triton_serve.api.services.observe import observe
@@ -15,6 +16,10 @@ from triton_serve.database.model import DesiredState, RuntimeStatus, Service
 from triton_serve.extensions import get_reconciler_docker_client
 
 LOG = logging.getLogger(__name__)
+
+# single-flight guard: only one reconcile pass may touch Docker at a time. an overrunning tick
+# (slow daemon, image pull) must never run concurrently with the next and both decide RECREATE.
+_RECONCILE_LOCK_KEY = 0x7213_10CE
 
 settings = get_settings()
 app = Celery("serve-sentinel")
@@ -54,42 +59,51 @@ def update_service_status() -> None:
     """Reconcile every non-retired service: observe -> decide -> execute. Reconciler owns Docker."""
     client = get_reconciler_docker_client()
     now = datetime.now(tz=timezone.utc)
-    with database_manager.session() as db:
-        services = db.query(Service).filter(Service.runtime_status != RuntimeStatus.RETIRED).all()
-        for service in services:
-            try:
-                # reset the crash budget once the cooldown has elapsed since the last attempt
-                if (
-                    service.last_attempt_at is not None
-                    and (now - service.last_attempt_at).total_seconds() > settings.service_restart_cooldown
-                ):
-                    service.restart_attempts = 0
+    # single-flight across the whole pass: hold the advisory lock on a dedicated connection so it
+    # survives the per-service commits below -- an ORM session releases its connection on each commit,
+    # which would strand the lock on a pooled connection and unlock a different one
+    with database_manager.connect() as lock_conn:
+        if not lock_conn.execute(text("SELECT pg_try_advisory_lock(:k)"), {"k": _RECONCILE_LOCK_KEY}).scalar():
+            LOG.info("another reconcile pass holds the advisory lock; skipping this tick")
+            return
+        try:
+            with database_manager.session() as db:
+                services = db.query(Service).filter(Service.runtime_status != RuntimeStatus.RETIRED).all()
+                for service in services:
+                    try:
+                        # honor backoff: skip a service mid-retry still cooling down between attempts.
+                        # RECOVERING is the status the executor persists after any spent attempt (crash
+                        # recreate or image pull), so image-pull failures draw on the same crash budget
+                        if (
+                            service.runtime_status == RuntimeStatus.RECOVERING
+                            and service.restart_attempts > 0
+                            and service.last_attempt_at is not None
+                            and (now - service.last_attempt_at).total_seconds()
+                            < _backoff_seconds(
+                                service.restart_attempts,
+                                base=settings.service_restart_backoff_base,
+                                cap=settings.service_restart_cooldown,
+                            )
+                        ):
+                            continue
 
-                # honor backoff: skip a service mid-retry that is still cooling down between attempts.
-                # RECOVERING is the status the executor persists after any spent attempt (crash recreate
-                # or image pull), so image-pull failures draw on the same budget as crash loops
-                if (
-                    service.runtime_status == RuntimeStatus.RECOVERING
-                    and service.restart_attempts > 0
-                    and service.last_attempt_at is not None
-                    and (now - service.last_attempt_at).total_seconds()
-                    < _backoff_seconds(service.restart_attempts, base=10, cap=settings.service_restart_cooldown)
-                ):
-                    continue
-
-                target = _replica_target(service, now) if service.desired_state == DesiredState.AVAILABLE else 0
-                observed = observe(client, service, settings.service_boot_grace)
-                decision = decide(
-                    desired=service.desired_state,
-                    observed=observed,
-                    replica_target=target,
-                    attempts=service.restart_attempts,
-                    max_attempts=settings.service_max_restart_attempts,
-                )
-                execute(db=db, client=client, service=service, decision=decision, settings=settings)
-            except Exception as e:
-                LOG.error("Reconcile failed for service %s: %s", service.service_id, e)
-                db.rollback()
+                        target = (
+                            _replica_target(service, now) if service.desired_state == DesiredState.AVAILABLE else 0
+                        )
+                        observed = observe(client, service, settings.service_boot_grace)
+                        decision = decide(
+                            desired=service.desired_state,
+                            observed=observed,
+                            replica_target=target,
+                            attempts=service.restart_attempts,
+                            max_attempts=settings.service_max_restart_attempts,
+                        )
+                        execute(db=db, client=client, service=service, decision=decision, settings=settings)
+                    except Exception as e:
+                        LOG.error("Reconcile failed for service %s: %s", service.service_id, e)
+                        db.rollback()
+        finally:
+            lock_conn.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": _RECONCILE_LOCK_KEY})
 
 
 @app.task

--- a/src/triton_serve/tasks.py
+++ b/src/triton_serve/tasks.py
@@ -65,9 +65,12 @@ def update_service_status() -> None:
                 ):
                     service.restart_attempts = 0
 
-                # honor backoff: skip a service still cooling down between crash attempts
+                # honor backoff: skip a service mid-retry that is still cooling down between attempts.
+                # RECOVERING is the status the executor persists after any spent attempt (crash recreate
+                # or image pull), so image-pull failures draw on the same budget as crash loops
                 if (
                     service.runtime_status == RuntimeStatus.RECOVERING
+                    and service.restart_attempts > 0
                     and service.last_attempt_at is not None
                     and (now - service.last_attempt_at).total_seconds()
                     < _backoff_seconds(service.restart_attempts, base=10, cap=settings.service_restart_cooldown)

--- a/src/triton_serve/tasks.py
+++ b/src/triton_serve/tasks.py
@@ -4,11 +4,15 @@ from datetime import datetime, timezone
 from celery import Celery
 from httpx import Client
 
+from triton_serve.api.services.execute import execute
+from triton_serve.api.services.observe import observe
+from triton_serve.api.services.reconcile import decide
 from triton_serve.config import get_settings
 from triton_serve.config.celery import Config
 from triton_serve.config.celery import client as worker_client
-from triton_serve.database.model import ServiceStatus
-from triton_serve.database.schema import ServiceSchema
+from triton_serve.database import database_manager
+from triton_serve.database.model import DesiredState, RuntimeStatus, Service
+from triton_serve.extensions import get_reconciler_docker_client
 
 LOG = logging.getLogger(__name__)
 
@@ -35,36 +39,54 @@ def setup_periodic_tasks(sender, **_):
     )
 
 
+def _replica_target(service: Service, now: datetime) -> int:
+    """1 if within the inactivity window (recent traffic / wake), else 0. AVAILABLE only."""
+    idle_for = (now - service.last_active_time).total_seconds()
+    return 1 if idle_for < service.inactivity_timeout else 0
+
+
+def _backoff_seconds(attempts: int, base: int, cap: int) -> int:
+    return min(base * (2 ** max(attempts - 1, 0)), cap)
+
+
 @app.task
-def update_service_status(client: Client | None = None) -> None:
-    """
-    Checks the status of the container.
-    """
-    client = client or worker_client
-    assert client is not None
-    try:
-        response = client.get("/services")
-        json_response = response.json()
-        for service in json_response:
-            service = ServiceSchema(**service)
-            if service.container_status == ServiceStatus.MISSING:
-                LOG.info("Reconciling missing service %s", service.service_id)
-                response = client.post(f"/services/{service.service_id}/refresh")
-                LOG.debug("Service %s reconcile requested: %s", service.service_id, response.text)
-                continue
-            if service.container_status != ServiceStatus.ACTIVE:
-                continue
-            if not service.last_active_time:
-                up_time = 0
-            else:
-                up_time = (datetime.now(tz=timezone.utc) - service.last_active_time).total_seconds()
-            LOG.debug("Service %s has been inactive for %s seconds", service.service_id, up_time)
-            if up_time > service.inactivity_timeout:
-                LOG.info("Stopping service %s due to inactivity", service.service_id)
-                response = client.post(f"/services/{service.service_id}/stop")
-                LOG.debug("Service %s stopped: %s", service.service_id, response.text)
-    except Exception as e:
-        LOG.error("Error checking container status: %s", e)
+def update_service_status() -> None:
+    """Reconcile every non-retired service: observe -> decide -> execute. Reconciler owns Docker."""
+    client = get_reconciler_docker_client()
+    now = datetime.now(tz=timezone.utc)
+    with database_manager.session() as db:
+        services = db.query(Service).filter(Service.desired_state != DesiredState.RETIRED).all()
+        for service in services:
+            try:
+                # reset the crash budget once the cooldown has elapsed since the last attempt
+                if (
+                    service.last_attempt_at is not None
+                    and (now - service.last_attempt_at).total_seconds() > settings.service_restart_cooldown
+                ):
+                    service.restart_attempts = 0
+
+                # honor backoff: skip a service still cooling down between crash attempts
+                if (
+                    service.runtime_status == RuntimeStatus.RECOVERING
+                    and service.last_attempt_at is not None
+                    and (now - service.last_attempt_at).total_seconds()
+                    < _backoff_seconds(service.restart_attempts, base=10, cap=settings.service_restart_cooldown)
+                ):
+                    continue
+
+                target = _replica_target(service, now) if service.desired_state == DesiredState.AVAILABLE else 0
+                observed = observe(client, service, settings.service_boot_grace)
+                decision = decide(
+                    desired=service.desired_state,
+                    observed=observed,
+                    replica_target=target,
+                    attempts=service.restart_attempts,
+                    max_attempts=settings.service_max_restart_attempts,
+                )
+                execute(db=db, client=client, service=service, decision=decision, settings=settings)
+            except Exception as e:
+                LOG.error("Reconcile failed for service %s: %s", service.service_id, e)
+                db.rollback()
 
 
 @app.task

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,7 +65,7 @@ def test_create_api_key(test_client, key_type):
     assert "expires_at" in data
 
 
-@pytest.mark.order(after="test_services.py::test_delete_services")
+@pytest.mark.order(after="test_services.py::test_delete_is_db_only")
 def test_create_service_key(test_client, test_settings):
     service_name = "trt-srv_test_test_service"
     # First, create a service
@@ -195,7 +195,9 @@ def test_add_service_to_key(
 
 
 @pytest.mark.order(after="test_add_service_to_key")
-def test_check_service_status(test_client):
+def test_status_endpoint_auth(test_client, test_db):
+    from triton_serve.database.model import RuntimeStatus, Service
+
     # using the client, get the service key associated with test project
     response = test_client.get("/keys", params={"project": "status_check"})
     LOG.debug("Response: %s", response.text)
@@ -203,6 +205,11 @@ def test_check_service_status(test_client):
     data = response.json()
     assert len(data) > 0
     key = data[0]["value"]
+
+    # mark the service READY so a passing key projects to 200 (the request path never spawns)
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_another_test_service").one()
+    service.runtime_status = RuntimeStatus.READY
+    test_db.commit()
 
     # Test with user key
     response = test_client.get(

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,26 @@
+from triton_serve.api.services.domain import docker_healthcheck
+
+
+def test_no_healthcheck_is_none():
+    assert docker_healthcheck(None) is None
+
+
+def test_empty_healthcheck_is_none():
+    assert docker_healthcheck({}) is None
+
+
+def test_seconds_are_converted_to_nanoseconds():
+    stored = {
+        "test": ["CMD", "curl", "-f", "http://localhost:8000/v2/health/ready"],
+        "interval": 10,
+        "timeout": 5,
+        "retries": 3,
+        "start_period": 60,
+    }
+    assert docker_healthcheck(stored) == {
+        "Test": ["CMD", "curl", "-f", "http://localhost:8000/v2/health/ready"],
+        "Interval": 10_000_000_000,
+        "Timeout": 5_000_000_000,
+        "Retries": 3,
+        "StartPeriod": 60_000_000_000,
+    }

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from docker.errors import NotFound
 
 from triton_serve.api.services.observe import observe
-from triton_serve.api.services.reconcile import ObservedFact
+from triton_serve.api.services.reconcile import ObservedState
 
 
 def _svc(name="svc", image="img:1"):
@@ -54,53 +54,55 @@ def _container(status, exit_code=0, health=None, started=None):
 
 
 def test_absent_with_image_present_is_absent():
-    assert observe(FakeClient(container=None, image_present=True), _svc(), 30) is ObservedFact.ABSENT
+    assert observe(FakeClient(container=None, image_present=True), _svc(), 30) is ObservedState.ABSENT
 
 
 def test_absent_with_image_missing_is_image_missing():
-    assert observe(FakeClient(container=None, image_present=False), _svc(), 30) is ObservedFact.IMAGE_MISSING
+    assert observe(FakeClient(container=None, image_present=False), _svc(), 30) is ObservedState.IMAGE_MISSING
 
 
 def test_running_healthy_is_running():
     c = _container("running", health="healthy")
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.RUNNING
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.RUNNING
 
 
 def test_running_health_starting_is_booting():
     c = _container("running", health="starting", started=datetime.now(timezone.utc))
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.BOOTING
 
 
-def test_running_health_unhealthy_within_grace_is_booting():
+def test_running_health_unhealthy_is_crashed():
+    # docker only reports unhealthy past the start period and after the configured retries, so
+    # there is nothing left to wait for: the boot grace must not delay the verdict
     c = _container("running", health="unhealthy", started=datetime.now(timezone.utc))
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.CRASHED
 
 
 def test_running_health_stuck_past_grace_is_crashed():
-    # a container whose healthcheck never passes must not sit in BOOTING forever: past the boot
-    # grace it counts as crashed so the reconciler spends budget and eventually reaches FAILED
     c = _container("running", health="unhealthy", started=datetime.now(timezone.utc) - timedelta(seconds=120))
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.CRASHED
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.CRASHED
 
 
-def test_running_health_starting_past_grace_is_crashed():
+def test_running_health_starting_ignores_boot_grace():
+    # starting cannot hang forever, docker leaves it after the start period; calling it crashed on
+    # our own clock would recreate a container docker still considers to be warming up
     c = _container("running", health="starting", started=datetime.now(timezone.utc) - timedelta(seconds=120))
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.CRASHED
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.BOOTING
 
 
 def test_running_no_health_within_grace_is_booting():
     c = _container("running", started=datetime.now(timezone.utc))
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.BOOTING
 
 
 def test_running_no_health_past_grace_is_running():
     c = _container("running", started=datetime.now(timezone.utc) - timedelta(seconds=120))
-    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.RUNNING
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedState.RUNNING
 
 
 def test_exited_zero_is_exited_ok():
-    assert observe(FakeClient(container=_container("exited", 0)), _svc(), 30) is ObservedFact.EXITED_OK
+    assert observe(FakeClient(container=_container("exited", 0)), _svc(), 30) is ObservedState.EXITED_OK
 
 
 def test_exited_nonzero_is_crashed():
-    assert observe(FakeClient(container=_container("exited", 137)), _svc(), 30) is ObservedFact.CRASHED
+    assert observe(FakeClient(container=_container("exited", 137)), _svc(), 30) is ObservedState.CRASHED

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -71,6 +71,23 @@ def test_running_health_starting_is_booting():
     assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
 
 
+def test_running_health_unhealthy_within_grace_is_booting():
+    c = _container("running", health="unhealthy", started=datetime.now(timezone.utc))
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
+
+
+def test_running_health_stuck_past_grace_is_crashed():
+    # a container whose healthcheck never passes must not sit in BOOTING forever: past the boot
+    # grace it counts as crashed so the reconciler spends budget and eventually reaches FAILED
+    c = _container("running", health="unhealthy", started=datetime.now(timezone.utc) - timedelta(seconds=120))
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.CRASHED
+
+
+def test_running_health_starting_past_grace_is_crashed():
+    c = _container("running", health="starting", started=datetime.now(timezone.utc) - timedelta(seconds=120))
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.CRASHED
+
+
 def test_running_no_health_within_grace_is_booting():
     c = _container("running", started=datetime.now(timezone.utc))
     assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from docker.errors import NotFound
+
+from triton_serve.api.services.observe import observe
+from triton_serve.api.services.reconcile import ObservedFact
+
+
+def _svc(name="svc", image="img:1"):
+    return SimpleNamespace(service_name=name, service_image=image)
+
+
+class FakeContainers:
+    def __init__(self, container=None):
+        self._c = container
+
+    def get(self, name):
+        if self._c is None:
+            raise NotFound("absent")
+        return self._c
+
+
+class FakeImages:
+    def __init__(self, present):
+        self._present = present
+
+    def get(self, ref):
+        from docker.errors import ImageNotFound
+
+        if not self._present:
+            raise ImageNotFound(ref)
+        return SimpleNamespace(id=ref)
+
+
+class FakeClient:
+    def __init__(self, container=None, image_present=True):
+        self.containers = FakeContainers(container)
+        self.images = FakeImages(image_present)
+
+
+def _container(status, exit_code=0, health=None, started=None):
+    started = started or datetime.now(timezone.utc)
+    return SimpleNamespace(
+        status=status,
+        attrs={
+            "State": {
+                "ExitCode": exit_code,
+                "StartedAt": started.isoformat(),
+                "Health": {"Status": health} if health else {},
+            }
+        },
+    )
+
+
+def test_absent_with_image_present_is_absent():
+    assert observe(FakeClient(container=None, image_present=True), _svc(), 30) is ObservedFact.ABSENT
+
+
+def test_absent_with_image_missing_is_image_missing():
+    assert observe(FakeClient(container=None, image_present=False), _svc(), 30) is ObservedFact.IMAGE_MISSING
+
+
+def test_running_healthy_is_running():
+    c = _container("running", health="healthy")
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.RUNNING
+
+
+def test_running_health_starting_is_booting():
+    c = _container("running", health="starting", started=datetime.now(timezone.utc))
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
+
+
+def test_running_no_health_within_grace_is_booting():
+    c = _container("running", started=datetime.now(timezone.utc))
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.BOOTING
+
+
+def test_running_no_health_past_grace_is_running():
+    c = _container("running", started=datetime.now(timezone.utc) - timedelta(seconds=120))
+    assert observe(FakeClient(container=c), _svc(), 30) is ObservedFact.RUNNING
+
+
+def test_exited_zero_is_exited_ok():
+    assert observe(FakeClient(container=_container("exited", 0)), _svc(), 30) is ObservedFact.EXITED_OK
+
+
+def test_exited_nonzero_is_crashed():
+    assert observe(FakeClient(container=_container("exited", 137)), _svc(), 30) is ObservedFact.CRASHED

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,9 +1,9 @@
 import pytest
 
-from triton_serve.api.services.reconcile import Action, ObservedFact, decide
+from triton_serve.api.services.reconcile import Action, ObservedState, decide
 from triton_serve.database.model import DesiredState, RuntimeStatus
 
-A = ObservedFact
+A = ObservedState
 D = DesiredState
 R = RuntimeStatus
 
@@ -71,7 +71,7 @@ def test_failed_is_terminal_when_exhausted_across_bringup_facts():
         assert (d.action, d.status) == (Action.MARK_FAILED, R.FAILED)
 
 
-@pytest.mark.parametrize("observed", list(ObservedFact))
+@pytest.mark.parametrize("observed", list(ObservedState))
 def test_suspended_stops_live_else_noop(observed):
     d = decide(D.SUSPENDED, observed, replica_target=0, attempts=0, max_attempts=3)
     assert d.status == R.SUSPENDED
@@ -81,7 +81,7 @@ def test_suspended_stops_live_else_noop(observed):
         assert d.action == Action.NONE
 
 
-@pytest.mark.parametrize("observed", list(ObservedFact))
+@pytest.mark.parametrize("observed", list(ObservedState))
 def test_retired_removes_or_finalizes(observed):
     d = decide(D.RETIRED, observed, replica_target=0, attempts=0, max_attempts=3)
     assert d.status == R.RETIRED
@@ -93,6 +93,6 @@ def test_retired_removes_or_finalizes(observed):
 
 def test_decide_is_total():
     for desired in DesiredState:
-        for observed in ObservedFact:
+        for observed in ObservedState:
             for target in (0, 1):
                 assert decide(desired, observed, target, attempts=0, max_attempts=3) is not None

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -63,6 +63,14 @@ def test_available_booting_target1_waits_warming():
     assert (d.action, d.status) == (Action.NONE, R.WARMING)
 
 
+def test_failed_is_terminal_when_exhausted_across_bringup_facts():
+    # a FAILED (budget-exhausted) service must not auto-revive, even once its dead container is
+    # removed (-> ABSENT) or a stale exited one lingers (-> EXITED_OK)
+    for observed in (A.ABSENT, A.EXITED_OK, A.CRASHED, A.IMAGE_MISSING):
+        d = decide(D.AVAILABLE, observed, replica_target=1, attempts=3, max_attempts=3)
+        assert (d.action, d.status) == (Action.MARK_FAILED, R.FAILED)
+
+
 @pytest.mark.parametrize("observed", list(ObservedFact))
 def test_suspended_stops_live_else_noop(observed):
     d = decide(D.SUSPENDED, observed, replica_target=0, attempts=0, max_attempts=3)

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,90 @@
+import pytest
+
+from triton_serve.api.services.reconcile import Action, ObservedFact, decide
+from triton_serve.database.model import DesiredState, RuntimeStatus
+
+A = ObservedFact
+D = DesiredState
+R = RuntimeStatus
+
+
+def test_available_running_target1_is_ready():
+    d = decide(D.AVAILABLE, A.RUNNING, replica_target=1, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.NONE, R.READY)
+
+
+def test_available_running_target0_stops_to_idle():
+    d = decide(D.AVAILABLE, A.RUNNING, replica_target=0, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.STOP, R.IDLE)
+
+
+def test_available_absent_target1_recreates_the_outage_cell():
+    d = decide(D.AVAILABLE, A.ABSENT, replica_target=1, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.RECREATE, R.WARMING)
+
+
+def test_available_absent_target0_is_idle_no_action():
+    d = decide(D.AVAILABLE, A.ABSENT, replica_target=0, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.NONE, R.IDLE)
+
+
+def test_available_exited_ok_target1_starts():
+    d = decide(D.AVAILABLE, A.EXITED_OK, replica_target=1, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.START, R.WARMING)
+
+
+def test_available_crashed_within_budget_recovers_and_increments():
+    d = decide(D.AVAILABLE, A.CRASHED, replica_target=1, attempts=1, max_attempts=3)
+    assert (d.action, d.status, d.increment_attempt) == (Action.RECREATE, R.RECOVERING, True)
+
+
+def test_available_crashed_budget_exhausted_fails():
+    d = decide(D.AVAILABLE, A.CRASHED, replica_target=1, attempts=3, max_attempts=3)
+    assert (d.action, d.status) == (Action.MARK_FAILED, R.FAILED)
+
+
+def test_available_crashed_target0_defers_but_flags_failed_if_spent():
+    assert decide(D.AVAILABLE, A.CRASHED, 0, attempts=0, max_attempts=3).status == R.IDLE
+    assert decide(D.AVAILABLE, A.CRASHED, 0, attempts=3, max_attempts=3).status == R.FAILED
+
+
+def test_available_image_missing_target1_pulls():
+    d = decide(D.AVAILABLE, A.IMAGE_MISSING, replica_target=1, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.PULL, R.WARMING)
+
+
+def test_available_image_missing_exhausted_fails():
+    d = decide(D.AVAILABLE, A.IMAGE_MISSING, replica_target=1, attempts=3, max_attempts=3)
+    assert (d.action, d.status) == (Action.MARK_FAILED, R.FAILED)
+
+
+def test_available_booting_target1_waits_warming():
+    d = decide(D.AVAILABLE, A.BOOTING, replica_target=1, attempts=0, max_attempts=3)
+    assert (d.action, d.status) == (Action.NONE, R.WARMING)
+
+
+@pytest.mark.parametrize("observed", list(ObservedFact))
+def test_suspended_stops_live_else_noop(observed):
+    d = decide(D.SUSPENDED, observed, replica_target=0, attempts=0, max_attempts=3)
+    assert d.status == R.SUSPENDED
+    if observed in (A.RUNNING, A.BOOTING):
+        assert d.action == Action.STOP
+    else:
+        assert d.action == Action.NONE
+
+
+@pytest.mark.parametrize("observed", list(ObservedFact))
+def test_retired_removes_or_finalizes(observed):
+    d = decide(D.RETIRED, observed, replica_target=0, attempts=0, max_attempts=3)
+    assert d.status == R.RETIRED
+    if observed in (A.RUNNING, A.BOOTING, A.EXITED_OK, A.CRASHED):
+        assert d.action == Action.REMOVE
+    else:
+        assert d.action == Action.FINALIZE
+
+
+def test_decide_is_total():
+    for desired in DesiredState:
+        for observed in ObservedFact:
+            for target in (0, 1):
+                assert decide(desired, observed, target, attempts=0, max_attempts=3) is not None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -662,6 +662,29 @@ def test_reconcile_clears_name_squatter(test_docker, test_db, test_settings):
 
 
 @pytest.mark.order(after="test_update_service_recreate")
+def test_execute_recreates_absent(test_db, test_docker, test_settings):
+    from triton_serve.api.services.execute import execute
+    from triton_serve.api.services.reconcile import Action, Decision
+    from triton_serve.database.model import RuntimeStatus, Service
+
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc2").one()
+    # simulate a vanished container: point the record at a non-existent id
+    service.container_id = "deadbeefdead"
+    test_db.commit()
+
+    execute(
+        db=test_db,
+        client=test_docker,
+        service=service,
+        decision=Decision(Action.RECREATE, RuntimeStatus.WARMING),
+        settings=test_settings,
+    )
+    test_db.refresh(service)
+    assert service.runtime_status == RuntimeStatus.WARMING
+    assert test_docker.containers.get(service.service_name) is not None
+
+
+@pytest.mark.order(after="test_update_service_recreate")
 def test_delete_services(test_client, test_docker, test_db):
     # get all services
     services = test_db.query(Service).all()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -232,7 +232,7 @@ def test_update_service_wrong_inputs(test_client, service_id, update_body, expec
 
 
 @pytest.mark.order(after="test_update_service")
-def test_status_projection_codes(test_client, test_db):
+def test_status_projection_codes(test_client, test_db, test_settings):
     svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").one()
 
     svc.desired_state, svc.runtime_status = DesiredState.AVAILABLE, RuntimeStatus.READY
@@ -242,7 +242,8 @@ def test_status_projection_codes(test_client, test_db):
     svc.runtime_status = RuntimeStatus.IDLE
     test_db.commit()
     r = test_client.get("/status/trt-srv_test_svc3")
-    assert r.status_code == 503 and r.headers.get("Retry-After") == "2"
+    # Retry-After tracks the reconcile tick so a client polls about once per bring-up opportunity
+    assert r.status_code == 503 and r.headers.get("Retry-After") == str(test_settings.sentinel_poll_interval)
 
     svc.desired_state, svc.runtime_status = DesiredState.SUSPENDED, RuntimeStatus.SUSPENDED
     test_db.commit()
@@ -378,3 +379,53 @@ def test_bad_image_service_ends_failed(test_db, test_docker, test_settings):
     assert status == RuntimeStatus.FAILED, f"bad-image service did not reach FAILED, stuck at {status}"
     with pytest.raises(NotFound):
         test_docker.containers.get(name)
+
+
+@pytest.mark.order(after="test_bad_image_service_ends_failed")
+def test_failed_stays_terminal_after_cooldown(test_db, test_settings):
+    """FAILED is terminal: elapsed time must NOT resurrect a failed service by silently resetting
+    its crash budget. Before the fix, any FAILED service revived one cooldown after its last attempt;
+    only POST /retry may reset the budget now."""
+    from datetime import datetime, timedelta, timezone
+
+    svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_badimg").one()
+    assert svc.runtime_status == RuntimeStatus.FAILED
+    # push the last attempt well past the reset window -- the old time-based reset would revive it
+    svc.last_attempt_at = datetime.now(timezone.utc) - timedelta(seconds=test_settings.service_restart_cooldown + 60)
+    test_db.commit()
+
+    update_service_status.apply()
+    test_db.refresh(svc)
+    assert svc.runtime_status == RuntimeStatus.FAILED, "an elapsed cooldown resurrected a FAILED service"
+    assert svc.restart_attempts == test_settings.service_max_restart_attempts, "crash budget was silently reset"
+
+
+@pytest.mark.order(after="test_failed_stays_terminal_after_cooldown")
+def test_budget_returns_after_sustained_ready(test_db, test_docker, test_settings):
+    """A recovered service that stays READY past the cooldown earns its crash budget back, but a
+    brief READY within the cooldown does not (so a fast crash-recover-crash flap cannot loop)."""
+    from datetime import datetime, timedelta, timezone
+
+    from triton_serve.api.services.execute import execute
+    from triton_serve.api.services.reconcile import Action, Decision
+
+    svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_badimg").one()
+    ready = Decision(Action.NONE, RuntimeStatus.READY)
+
+    # within the cooldown: a fresh recovery attempt has not yet proven stable -> keep the budget spent
+    svc.restart_attempts = 2
+    svc.last_attempt_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    svc.runtime_status = RuntimeStatus.RECOVERING
+    test_db.commit()
+    execute(db=test_db, client=test_docker, service=svc, decision=ready, settings=test_settings)
+    test_db.refresh(svc)
+    assert svc.restart_attempts == 2
+
+    # past the cooldown: sustained health returns the budget
+    svc.last_attempt_at = datetime.now(timezone.utc) - timedelta(seconds=test_settings.service_restart_cooldown + 60)
+    test_db.commit()
+    execute(db=test_db, client=test_docker, service=svc, decision=ready, settings=test_settings)
+    test_db.refresh(svc)
+    assert svc.restart_attempts == 0
+    assert svc.last_attempt_at is None
+    assert svc.runtime_status == RuntimeStatus.READY

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -322,9 +322,9 @@ def test_reconciler_idles_then_wakes(test_db, test_docker, test_settings):
 
     svc.last_active_time = datetime.now(timezone.utc)
     test_db.commit()
-    update_service_status.apply()  # target back to 1 -> start/recreate
-    test_db.refresh(svc)
-    assert svc.runtime_status in (RuntimeStatus.WARMING, RuntimeStatus.READY, RuntimeStatus.IDLE)
+    # target back to 1 -> the reconciler must actually bring it up; IDLE would mean it never woke
+    status = _drive_reconciler(test_db, svc, until={RuntimeStatus.WARMING, RuntimeStatus.READY}, ticks=6, delay=2)
+    assert status in (RuntimeStatus.WARMING, RuntimeStatus.READY), f"service did not wake, stuck at {status}"
 
 
 @pytest.mark.order(after="test_reconciler_idles_then_wakes")
@@ -342,3 +342,39 @@ def test_delete_is_db_only(test_client, test_db):
 
     listing = test_client.get("/services").json()
     assert listing == []
+
+
+@pytest.mark.order(after="test_delete_is_db_only")
+def test_bad_image_service_ends_failed(test_db, test_docker, test_settings):
+    """Spec headline guarantee: a bad image ref surfaces asynchronously as FAILED within the crash
+    budget, and the reconciler does not spin forever recreating (the C1 regression). Self-contained
+    (direct DB insert, no models) and ordered last so it cannot disturb the ordered lifecycle chain."""
+    from datetime import datetime, timedelta, timezone
+
+    from docker.errors import NotFound
+
+    name = "trt-srv_test_badimg"
+    svc = Service(
+        service_name=name,
+        service_image="ghcr.io/links-ads/does-not-exist:0",
+        priority=1,
+        last_active_time=datetime.now(timezone.utc),
+        desired_state=DesiredState.AVAILABLE,
+        runtime_status=RuntimeStatus.WARMING,
+    )
+    test_db.add(svc)
+    test_db.commit()
+
+    # C1: a failed pull spends the budget instead of looping at attempts=0 forever
+    update_service_status.apply()
+    test_db.refresh(svc)
+    assert svc.restart_attempts >= 1, "failed pull did not advance the crash budget"
+
+    # exhaust the budget (bypass the real backoff wait) and confirm it lands terminal in FAILED
+    svc.restart_attempts = test_settings.service_max_restart_attempts
+    svc.last_attempt_at = datetime.now(timezone.utc) - timedelta(seconds=120)
+    test_db.commit()
+    status = _drive_reconciler(test_db, svc, until={RuntimeStatus.FAILED}, ticks=4, delay=2)
+    assert status == RuntimeStatus.FAILED, f"bad-image service did not reach FAILED, stuck at {status}"
+    with pytest.raises(NotFound):
+        test_docker.containers.get(name)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -187,7 +187,7 @@ def test_stop_service(
     time.sleep(5)
     # Manually execute the update service status task: one of the services should be stopped
     # due to the timeout, the other should be running.
-    update_service_status.apply(kwargs={"client": test_client})
+    update_service_status.apply()
     assert test_docker.containers.get(service_name).status == service_container_status
 
 
@@ -525,7 +525,7 @@ def test_sentinel_reconciles_missing(test_client, test_docker, test_db):
     test_db.refresh(service)
     assert service.container_status == ServiceStatus.MISSING
 
-    update_service_status.apply(kwargs={"client": test_client})
+    update_service_status.apply()
 
     test_db.refresh(service)
     assert service.container_status == ServiceStatus.STARTING
@@ -577,7 +577,7 @@ def test_deleted_service_excluded_from_listing(test_client, test_docker, test_db
     assert all(s["service_id"] != service_id for s in listing)
 
     # the sentinel polls the same listing, so a deleted service is never reconciled
-    update_service_status.apply(kwargs={"client": test_client})
+    update_service_status.apply()
     test_db.refresh(service)
     assert service.container_status == ServiceStatus.MISSING
 
@@ -682,6 +682,28 @@ def test_execute_recreates_absent(test_db, test_docker, test_settings):
     test_db.refresh(service)
     assert service.runtime_status == RuntimeStatus.WARMING
     assert test_docker.containers.get(service.service_name) is not None
+
+
+@pytest.mark.order(after="test_execute_recreates_absent")
+def test_reconciler_idles_then_wakes(test_db, test_docker, test_settings):
+    """The reconciler scales an idle service to zero, then wakes it once it sees traffic again."""
+    from datetime import datetime, timezone
+
+    from triton_serve.database.model import DesiredState, RuntimeStatus
+
+    svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc4").one()  # timeout=5s
+    svc.desired_state = DesiredState.AVAILABLE
+    test_db.commit()
+    time.sleep(6)  # exceed the 5s inactivity window
+    update_service_status.apply()
+    test_db.refresh(svc)
+    assert svc.runtime_status == RuntimeStatus.IDLE  # scaled to zero, container stopped
+
+    svc.last_active_time = datetime.now(timezone.utc)
+    test_db.commit()
+    update_service_status.apply()  # target back to 1 -> start/recreate
+    test_db.refresh(svc)
+    assert svc.runtime_status in (RuntimeStatus.WARMING, RuntimeStatus.READY)
 
 
 @pytest.mark.order(after="test_update_service_recreate")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,21 +3,33 @@ import time
 
 import pytest
 import requests
-from docker.errors import NotFound
 
-from triton_serve.database.model import Device, Service, ServiceStatus
+from triton_serve.database.model import DesiredState, Device, RuntimeStatus, Service
 from triton_serve.tasks import update_service_status
 
 LOG = logging.getLogger(pytest.__name__)
 
 
-def test_missing_status_and_retry_fields():
+def _drive_reconciler(test_db, service, until, ticks=24, delay=5):
+    """Manually tick the reconciler (no celery beat in test mode) until `service` reaches a
+    target runtime_status, refreshing the ORM object between ticks. Returns the final status."""
+    for _ in range(ticks):
+        update_service_status.apply()
+        test_db.refresh(service)
+        if service.runtime_status in until:
+            break
+        time.sleep(delay)
+    return service.runtime_status
+
+
+def test_lifecycle_fields_and_settings():
     from triton_serve.config import get_settings
     from triton_serve.database.schema import ServiceSchema
 
-    assert ServiceStatus.MISSING.value == "missing"
     assert "restart_attempts" in ServiceSchema.model_fields
     assert "last_attempt_at" in ServiceSchema.model_fields
+    assert "runtime_status" in ServiceSchema.model_fields
+    assert "desired_state" in ServiceSchema.model_fields
 
     settings = get_settings()
     assert settings.service_max_restart_attempts == 3
@@ -34,8 +46,6 @@ def test_retry_columns_exist(test_db):
 def test_lifecycle_enums_and_columns(test_db):
     from sqlalchemy import inspect
 
-    from triton_serve.database.model import DesiredState, RuntimeStatus
-
     assert {s.value for s in DesiredState} == {"available", "suspended", "retired"}
     assert {s.value for s in RuntimeStatus} == {
         "ready",
@@ -48,82 +58,50 @@ def test_lifecycle_enums_and_columns(test_db):
     }
     cols = {c["name"] for c in inspect(test_db.connection()).get_columns("services")}
     assert {"desired_state", "runtime_status"} <= cols
-    # expand phase: the old column still exists; it is dropped in Task 6 once nothing reads it
-    assert "container_status" in cols
 
 
 @pytest.mark.order(after="test_auth.py::test_api_key_authorized")
 @pytest.mark.parametrize(
     "name, models, resources, timeout",
     [
-        (
-            "trt-srv_test_svc1",
-            ["squeezenet"],
-            {"gpus": 0.5, "shm_size": 256, "mem_size": 1024},
-            3600,
-        ),
-        (
-            "trt-srv_test_svc6",
-            ["squeezenet"],
-            {"gpus": 0.4, "shm_size": 256, "mem_size": 256},
-            3600,
-        ),
-        (
-            "trt-srv_test_svc4",
-            ["ensemble_py_step", "ensemble"],
-            {"gpus": 0, "shm_size": 256, "mem_size": 1024},
-            5,  # set timeout low to test stopping the service
-        ),
-        (
-            "trt-srv_test_svc3",
-            ["onnx"],
-            {"gpus": 0, "shm_size": 256, "mem_size": 1024},
-            3600,
-        ),
-        (
-            "trt-srv_test_svc2",
-            ["onnx"],
-            {"gpus": 0, "shm_size": 256, "mem_size": 1024},
-            3600,
-        ),
+        ("trt-srv_test_svc1", ["squeezenet"], {"gpus": 0.5, "shm_size": 256, "mem_size": 1024}, 3600),
+        ("trt-srv_test_svc6", ["squeezenet"], {"gpus": 0.4, "shm_size": 256, "mem_size": 256}, 3600),
+        ("trt-srv_test_svc4", ["ensemble_py_step", "ensemble"], {"gpus": 0, "shm_size": 256, "mem_size": 1024}, 5),
+        ("trt-srv_test_svc3", ["onnx"], {"gpus": 0, "shm_size": 256, "mem_size": 1024}, 3600),
+        ("trt-srv_test_svc2", ["onnx"], {"gpus": 0, "shm_size": 256, "mem_size": 1024}, 3600),
     ],
 )
-def test_create_service(test_client, test_docker, test_db, name, models, resources, timeout):
-    # get the devices to also check creation when no GPU is available
+def test_create_service(test_client, test_db, name, models, resources, timeout):
+    """Create is declarative: a 201 record with runtime_status=WARMING and no container yet."""
     devices = set(test_db.query(Device.uuid).all())
 
     response = test_client.post(
         "/services",
-        json={
-            "name": name,
-            "models": models,
-            "resources": resources,
-            "timeout": timeout,
-        },
+        json={"name": name, "models": models, "resources": resources, "timeout": timeout},
     )
     LOG.debug(f"response: {response.text}")
     if resources["gpus"] and not devices:
         assert response.status_code == 409
-    else:
-        assert response.status_code == 201
-        data = response.json()
-        assert data["service_name"] == name
-        assert data["created_at"] is not None
-        # check if container is running
-        container = test_docker.containers.get(name)
-        assert container.status == "running", f"Container {name} is not created"
+        return
 
-        # check if service is in db
-        service = test_db.get(Service, ident=data["service_id"])
-        assert service.resources is not None
-        assert service.resources.shm_size == resources["shm_size"]
-        assert service.resources.mem_size == resources["mem_size"]
-        assert service.service_name == name
-        LOG.debug(f"assigned device: {service.device_allocations}")
-        if resources["gpus"]:
-            assert service.device_allocations is not None
-        else:
-            assert not service.device_allocations
+    assert response.status_code == 201
+    data = response.json()
+    assert data["service_name"] == name
+    assert data["created_at"] is not None
+    # declarative contract: warming intent, container spawned by the reconciler out of band
+    assert data["runtime_status"] == RuntimeStatus.WARMING.value
+    assert data["desired_state"] == DesiredState.AVAILABLE.value
+    assert data["container_id"] is None
+
+    service = test_db.get(Service, ident=data["service_id"])
+    assert service.resources is not None
+    assert service.resources.shm_size == resources["shm_size"]
+    assert service.resources.mem_size == resources["mem_size"]
+    assert service.service_name == name
+    if resources["gpus"]:
+        assert service.device_allocations
+    else:
+        assert not service.device_allocations
 
 
 @pytest.mark.order(after="test_create_service")
@@ -140,7 +118,6 @@ def test_get_service_config(test_client, test_db):
     assert data["resources"]["mem_size"] == 1024
     assert data["resources"]["gpus"] == 0.0
 
-    # verify non-existent service returns 404
     assert test_client.get("/services/-1/config").status_code == 404
 
 
@@ -154,153 +131,43 @@ def test_delete_model_in_use(name, test_client, test_settings):
     assert expected_path.exists()
 
 
-@pytest.mark.order(after="test_create_service")
-@pytest.mark.parametrize(
-    "service_name, service_container_status",
-    [
-        ("trt-srv_test_svc4", "exited"),
-        ("trt-srv_test_svc2", "running"),
-    ],
-)
-def test_stop_service(
-    test_client,
-    test_docker,
-    test_db,
-    service_name,
-    service_container_status,
-):
-    # make sure the service is running
-    for _ in range(3):
-        container_status = test_docker.containers.get(service_name).status
-        LOG.debug(f"container status: {container_status}")
-        if container_status == "running":
-            break
-        LOG.debug(f"{service_name} is not {service_container_status} yet ...")
-
-    # assert that the initial status is indeed "running"
-    init_status = test_docker.containers.get(service_name).status
-    init_service = test_db.query(Service).filter(Service.service_name == service_name).first()
-    LOG.debug(f"service: {init_service}")
-    assert init_status == "running"
-    assert init_service.container_status in (ServiceStatus.ACTIVE, ServiceStatus.STARTING)
-    # make sure we update the service status once the timeout has passed
-    time.sleep(5)
-    # Manually execute the update service status task: one of the services should be stopped
-    # due to the timeout, the other should be running.
-    update_service_status.apply()
-    assert test_docker.containers.get(service_name).status == service_container_status
-
-
-@pytest.mark.order(after="test_stop_service")
-@pytest.mark.parametrize(
-    "service_name, service_container_status, expected_status",
-    [
-        ("trt-srv_test_svc4", "exited", 204),
-        ("trt-srv_test_svc3", "running", 204),
-    ],
-)
-def test_refresh_services(test_docker, test_db, test_client, service_name, service_container_status, expected_status):
-    service = test_db.query(Service).filter(Service.service_name == service_name).first()
-    initial_srv_status = service.container_status
-    service_id = service.service_id if service else -1
-    response = test_client.post(f"/services/{service_id}/refresh")
-    LOG.debug(f"response: {response.text}")
-    assert response.status_code == expected_status
-    # check if the container status is the same as the expected status
-    assert test_docker.containers.get(service_name).status == service_container_status
-    service = test_db.query(Service).filter(Service.service_name == service_name).first()
-    assert service.container_status == initial_srv_status
-
-
-@pytest.mark.order(after="test_refresh_services")
-def test_refresh_non_existent(test_client):
-    response = test_client.post("/services/-1/refresh")
-    LOG.debug(f"response: {response.text}")
-    assert response.status_code == 404
-
-
-@pytest.mark.order(after="test_restart_services")
-def test_refresh_force_recreate(test_client, test_docker, test_db):
-    """force_recreate should tear down and respawn the container regardless of current state."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc4").first()
-    service_id = service.service_id
-
-    response = test_client.post(f"/services/{service_id}/refresh", params={"force_recreate": True})
-    LOG.debug(f"response: {response.text}")
-    assert response.status_code == 204
-
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.STARTING
-    container = test_docker.containers.get("trt-srv_test_svc4")
+@pytest.mark.order(after="test_get_service_config")
+def test_reconciler_brings_service_ready(test_db, test_docker):
+    """The reconciler spawns and readies a declaratively-created service on its ticks."""
+    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc2").one()
+    status = _drive_reconciler(test_db, service, until={RuntimeStatus.READY}, ticks=36, delay=5)
+    assert status == RuntimeStatus.READY, f"service did not become READY, stuck at {status}"
+    container = test_docker.containers.get("trt-srv_test_svc2")
     assert container.status == "running"
 
 
-@pytest.mark.order(after="test_refresh_services")
-def test_restart_services(test_docker, test_settings, test_client):
-    # make sure it does not work without auth
-    response = requests.get("http://traefik/trt-srv_test_svc4/v2/health/ready")
-    LOG.debug(f"response: {response.text}")
-    assert response.status_code == 403
-    # make sure it returns a 404 for a non-existent service
-    headers = {"X-API-Key": test_settings.api_keys[0]}
-    response = requests.get(
-        "http://traefik/whatever/v2/health/ready",
-        headers=headers,
-    )
-    LOG.debug(f"response: {response.text}")
-    assert response.status_code == 404
-    # we need to 'manually' restart the service since there's no backed running
-    test_client.get("status/trt-srv_test_svc4")
-    # attempt a couple of times to get a response != 50x using traefik
-    for _ in range(3):
-        response = requests.get(
-            "http://traefik/trt-srv_test_svc4/v2/health/ready",
-            headers=headers,
-        )
-        LOG.debug(f"headers: {response.headers}")
-        LOG.debug(f"response: {response.text}")
-        if response.status_code not in (502, 503):
-            break
-        time.sleep(5)
-
-    assert response.status_code == 200
-    container = test_docker.containers.get("trt-srv_test_svc4")
-    assert container.status == "running"
-
-
-@pytest.mark.order(after="test_check_service_status")
-@pytest.mark.parametrize("name", ["trt-srv_test_svc2", "trt-srv_test_svc3"])
-def test_triton_ping_unathorized(name):
+@pytest.mark.order(after="test_reconciler_brings_service_ready")
+@pytest.mark.parametrize("name", ["trt-srv_test_svc2"])
+def test_triton_ping_unauthorized(name):
     url = f"http://traefik/{name}/v2/health/ready"
     response = requests.get(url)
-    # try three times to get a response, with a timeout of 60 seconds
     for _ in range(3):
         response = requests.get(url, timeout=60)
         LOG.debug(f"response: {response.text}")
         if response.status_code != 404:
             break
-        else:
-            time.sleep(5)
-
+        time.sleep(5)
     assert response.status_code == 403
-    data = response.json()
-    assert "Invalid API Key" in data["message"]
+    assert "Invalid API Key" in response.json()["message"]
 
 
-@pytest.mark.order(after="test_triton_ping_unathorized")
-@pytest.mark.parametrize("name", ["trt-srv_test_svc2", "trt-srv_test_svc3"])
+@pytest.mark.order(after="test_triton_ping_unauthorized")
+@pytest.mark.parametrize("name", ["trt-srv_test_svc2"])
 def test_triton_ping(name, test_settings):
     url = f"http://traefik/{name}/v2/health/ready"
     headers = {"X-API-Key": test_settings.api_keys[0]}
-    # try three times to get a response, with a timeout of 60 seconds
     response = None
-    for _ in range(3):
+    for _ in range(6):
         response = requests.get(url, timeout=60, headers=headers)
         LOG.debug(f"response: {response.text}")
         if response.status_code == 200:
             break
-        else:
-            time.sleep(5)
+        time.sleep(5)
     assert response and response.status_code == 200
 
 
@@ -309,15 +176,12 @@ def test_triton_ping(name, test_settings):
 def test_triton_models_ready(name, model, test_settings):
     url = f"http://traefik/{name}/v2/models/{model}/ready"
     headers = {"X-API-Key": test_settings.api_keys[0]}
-
-    # try three times to get a response, with a timeout of 60 seconds
     response = None
-    for _ in range(3):
+    for _ in range(6):
         response = requests.get(url, timeout=60, headers=headers)
         if response.status_code == 200:
             break
-        else:
-            time.sleep(5)
+        time.sleep(5)
     assert response and response.status_code == 200
 
 
@@ -353,26 +217,6 @@ def test_update_service(test_client, test_db):
     assert service.priority == 2
 
 
-@pytest.mark.order(after="test_update_service")
-def test_update_service_recreate(test_client, test_docker, test_db):
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc2").first()
-    service_id = service.service_id
-    old_container_id = service.container_id
-
-    response = test_client.put(f"/services/{service_id}", params={"recreate": True}, json={"timeout": 5400})
-    LOG.debug(f"response: {response.text}")
-    assert response.status_code == 200
-
-    data = response.json()
-    assert data["inactivity_timeout"] == 5400
-    test_db.refresh(service)
-    assert service.inactivity_timeout == 5400
-    assert service.container_status == ServiceStatus.STARTING
-    assert service.container_id != old_container_id
-    container = test_docker.containers.get("trt-srv_test_svc2")
-    assert container.status == "running"
-
-
 @pytest.mark.order(after="test_create_service_wrong_inputs")
 @pytest.mark.parametrize(
     "service_id, update_body, expected_status",
@@ -387,285 +231,64 @@ def test_update_service_wrong_inputs(test_client, service_id, update_body, expec
     assert response.status_code == expected_status
 
 
-@pytest.mark.order(after="test_update_service_recreate")
-def test_check_status_missing_is_observational(test_client, test_docker, test_db):
-    """A vanished container becomes MISSING, never DELETED, and is not auto-recreated by a read."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
+@pytest.mark.order(after="test_update_service")
+def test_status_projection_codes(test_client, test_db):
+    svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").one()
 
-    # remove the container out-of-band
-    test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
-
-    # a plain read must observe MISSING without spawning anything or deleting the service
-    response = test_client.get(f"/services/{service_id}")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["container_status"] == ServiceStatus.MISSING.value
-    assert data["deleted_at"] is None
-    with pytest.raises(NotFound):
-        test_docker.containers.get("trt-srv_test_svc3")
-
-    # restore for the rest of the suite
-    test_client.post(f"/services/{service_id}/refresh", params={"force_recreate": True})
-
-
-@pytest.mark.order(after="test_check_status_missing_is_observational")
-def test_missing_recreated_same_id_new_container(test_client, test_docker, test_db):
-    """A MISSING service is recreated with the same service_id and a fresh container_id."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
-    old_container_id = service.container_id
-
-    test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
-    # mark MISSING via an observational read
-    test_client.get(f"/services/{service_id}")
-
-    response = test_client.post(f"/services/{service_id}/refresh")
-    assert response.status_code == 204
-
-    test_db.refresh(service)
-    assert service.service_id == service_id
-    assert service.container_status == ServiceStatus.STARTING
-    assert service.container_id != old_container_id
-    assert test_docker.containers.get("trt-srv_test_svc3").status in ("running", "created")
-
-
-@pytest.mark.order(after="test_missing_recreated_same_id_new_container")
-def test_missing_recreate_no_double_spawn(test_docker, test_db, test_settings):
-    """Re-verify guard: reconcile on a MISSING service whose container is actually present must not spawn a new one."""
-    from triton_serve.api.services import domain
-
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    healthy_container_id = service.container_id
-    # force MISSING while the container is genuinely still present
-    service.container_status = ServiceStatus.MISSING
+    svc.desired_state, svc.runtime_status = DesiredState.AVAILABLE, RuntimeStatus.READY
     test_db.commit()
+    assert test_client.get("/status/trt-srv_test_svc3").status_code == 200
 
-    domain.reconcile_missing_container(
-        db=test_db,
-        client=test_docker,
-        service=service,
-        service_network=test_settings.service_network,
-        service_models_volume=test_settings.service_volume,
-        max_restart_attempts=test_settings.service_max_restart_attempts,
-        restart_cooldown=test_settings.service_restart_cooldown,
-    )
-
-    test_db.refresh(service)
-    # the re-verify guard saw the container present -> no new container, no extra attempt
-    assert service.container_id == healthy_container_id
-    assert service.container_status != ServiceStatus.MISSING
-
-
-@pytest.mark.order(after="test_missing_recreate_no_double_spawn")
-def test_missing_exhaustion_to_error_then_recovery(test_client, test_docker, test_db):
-    """Repeated recreate failures land the service in ERROR, recoverable via force_recreate."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
-    good_image = service.service_image
-
-    # force every recreate attempt to fail by pointing at a bogus image
-    service.service_image = "ghcr.io/links-ads/does-not-exist:0"
-    service.container_status = ServiceStatus.MISSING
-    service.restart_attempts = 0
-    service.last_attempt_at = None
+    svc.runtime_status = RuntimeStatus.IDLE
     test_db.commit()
-    try:
-        test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
-    except NotFound:
-        pass
+    r = test_client.get("/status/trt-srv_test_svc3")
+    assert r.status_code == 503 and r.headers.get("Retry-After") == "2"
 
-    # drive past the budget: max_restart_attempts (3) spawn attempts + 1 observation -> ERROR
-    for _ in range(5):
-        test_client.post(f"/services/{service_id}/refresh")
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.ERROR
-
-    # recover: restore a valid image and force_recreate
-    service.service_image = good_image
+    svc.desired_state, svc.runtime_status = DesiredState.SUSPENDED, RuntimeStatus.SUSPENDED
     test_db.commit()
-    response = test_client.post(f"/services/{service_id}/refresh", params={"force_recreate": True})
-    assert response.status_code == 204
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.STARTING
+    r = test_client.get("/status/trt-srv_test_svc3")
+    assert r.status_code == 503 and "Retry-After" not in r.headers
 
-    # leave a clean retry budget so downstream tests are not affected by exhaustion
-    service.restart_attempts = 0
-    service.last_attempt_at = None
+    svc.runtime_status = RuntimeStatus.RETIRED
+    test_db.commit()
+    assert test_client.get("/status/trt-srv_test_svc3").status_code == 404
+
+    # restore so downstream tests see an available service
+    svc.desired_state, svc.runtime_status = DesiredState.AVAILABLE, RuntimeStatus.READY
     test_db.commit()
 
 
-@pytest.mark.order(after="test_missing_exhaustion_to_error_then_recovery")
-def test_status_endpoint_recreates_missing(test_client, test_docker, test_db):
-    """GET /status on a MISSING service triggers recreation and returns 202."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
+@pytest.mark.order(after="test_status_projection_codes")
+def test_suspend_and_resume_set_intent(test_client, test_db):
+    svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").one()
 
-    test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
-    test_client.get(f"/services/{service_id}")  # observe -> MISSING
+    assert test_client.post(f"/services/{svc.service_id}/suspend").status_code == 204
+    test_db.refresh(svc)
+    assert svc.desired_state == DesiredState.SUSPENDED
 
-    response = test_client.get("/status/trt-srv_test_svc3")
-    assert response.status_code == 200  # decorator status; body carries the signal
-    assert response.json() == 202
-
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.STARTING
-    assert test_docker.containers.get("trt-srv_test_svc3").status in ("running", "created")
+    assert test_client.post(f"/services/{svc.service_id}/resume").status_code == 204
+    test_db.refresh(svc)
+    assert svc.desired_state == DesiredState.AVAILABLE
 
 
-@pytest.mark.order(after="test_status_endpoint_recreates_missing")
-def test_sentinel_reconciles_missing(test_client, test_docker, test_db):
-    """The sentinel task recreates a MISSING container via /refresh."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
-    old_container_id = service.container_id
-
-    test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
-    test_client.get(f"/services/{service_id}")  # observe -> MISSING
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.MISSING
-
-    update_service_status.apply()
-
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.STARTING
-    assert service.container_id != old_container_id
-
-
-@pytest.mark.order(after="test_sentinel_reconciles_missing")
-def test_check_status_preserves_terminal_states(test_client, test_docker, test_db):
-    """A vanished container must not drag a terminal ERROR/STOPPED service into MISSING."""
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
-    original_status = service.container_status
-
-    # remove the container out-of-band so the daemon reports it gone
-    try:
-        test_docker.containers.get("trt-srv_test_svc3").remove(force=True)
-    except NotFound:
-        pass
-
-    # an observational read finds the container gone but must leave a terminal state intact:
-    # only a previously-running service (ACTIVE/STARTING) may transition to MISSING
-    for terminal in (ServiceStatus.ERROR, ServiceStatus.STOPPED):
-        service.container_status = terminal
-        test_db.commit()
-        data = test_client.get(f"/services/{service_id}").json()
-        assert data["container_status"] == terminal.value
-
-    # restore for downstream tests
-    service.container_status = original_status
-    test_db.commit()
-    test_client.post(f"/services/{service_id}/refresh", params={"force_recreate": True})
-
-
-@pytest.mark.order(after="test_check_status_preserves_terminal_states")
-def test_deleted_service_excluded_from_listing(test_client, test_docker, test_db):
-    """Soft-deleted services must not appear in GET /services nor be revived by the sentinel."""
-    from datetime import datetime, timezone
-
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    service_id = service.service_id
-    original_deleted = service.deleted_at
-
-    # soft-delete the row (leave the container alone) and mark it MISSING as the daemon would
-    service.deleted_at = datetime.now(tz=timezone.utc)
-    service.container_status = ServiceStatus.MISSING
+@pytest.mark.order(after="test_suspend_and_resume_set_intent")
+def test_retry_resets_budget_and_recovers(test_client, test_db):
+    svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").one()
+    svc.restart_attempts = 3
+    svc.runtime_status = RuntimeStatus.FAILED
     test_db.commit()
 
-    listing = test_client.get("/services").json()
-    assert all(s["service_id"] != service_id for s in listing)
-
-    # the sentinel polls the same listing, so a deleted service is never reconciled
-    update_service_status.apply()
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.MISSING
-
-    service.deleted_at = original_deleted
-    test_db.commit()
+    assert test_client.post(f"/services/{svc.service_id}/retry").status_code == 204
+    test_db.refresh(svc)
+    assert svc.restart_attempts == 0
+    assert svc.last_attempt_at is None
+    assert svc.runtime_status == RuntimeStatus.RECOVERING
 
 
-@pytest.mark.order(after="test_deleted_service_excluded_from_listing")
-def test_reconcile_adopts_returned_container(test_docker, test_db, test_settings):
-    """Reconcile adopts a container that is back under the service name (new id), without respawning."""
-    from triton_serve.api.services import domain
-
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    name = service.service_name
-    real = test_docker.containers.get(name)
-    for _ in range(10):
-        real.reload()
-        if real.status == "running":
-            break
-        time.sleep(1)
-    assert real.status == "running"
-
-    # lose track of the id: MISSING with a stale container_id while the container is genuinely up
-    service.container_status = ServiceStatus.MISSING
-    service.container_id = "stale-id-0000"
-    service.restart_attempts = 0
-    service.last_attempt_at = None
-    test_db.commit()
-
-    domain.reconcile_missing_container(
-        db=test_db,
-        client=test_docker,
-        service=service,
-        service_network=test_settings.service_network,
-        service_models_volume=test_settings.service_volume,
-        max_restart_attempts=test_settings.service_max_restart_attempts,
-        restart_cooldown=test_settings.service_restart_cooldown,
-    )
-
-    test_db.refresh(service)
-    assert service.container_id == real.id  # adopted the existing container
-    assert service.container_status != ServiceStatus.MISSING
-    assert len([c for c in test_docker.containers.list(all=True) if c.name == name]) == 1
-
-
-@pytest.mark.order(after="test_reconcile_adopts_returned_container")
-def test_reconcile_clears_name_squatter(test_docker, test_db, test_settings):
-    """A stale/foreign container holding the name is removed so recreate doesn't 409."""
-    from triton_serve.api.services import domain
-
-    service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc3").first()
-    name = service.service_name
-    image = service.service_image
-
-    # tear down the real container and leave a foreign one squatting the name under a different id
-    try:
-        test_docker.containers.get(name).remove(force=True)
-    except NotFound:
-        pass
-    squatter = test_docker.containers.create(image=image, name=name)
-
-    service.container_status = ServiceStatus.MISSING
-    service.container_id = "stale-id-0000"
-    service.restart_attempts = 0
-    service.last_attempt_at = None
-    test_db.commit()
-
-    domain.reconcile_missing_container(
-        db=test_db,
-        client=test_docker,
-        service=service,
-        service_network=test_settings.service_network,
-        service_models_volume=test_settings.service_volume,
-        max_restart_attempts=test_settings.service_max_restart_attempts,
-        restart_cooldown=test_settings.service_restart_cooldown,
-    )
-
-    test_db.refresh(service)
-    assert service.container_status == ServiceStatus.STARTING  # recreated cleanly, no 409
-    assert service.container_id not in ("stale-id-0000", squatter.id)
-    assert len([c for c in test_docker.containers.list(all=True) if c.name == name]) == 1
-
-
-@pytest.mark.order(after="test_update_service_recreate")
+@pytest.mark.order(after="test_retry_resets_budget_and_recovers")
 def test_execute_recreates_absent(test_db, test_docker, test_settings):
     from triton_serve.api.services.execute import execute
     from triton_serve.api.services.reconcile import Action, Decision
-    from triton_serve.database.model import RuntimeStatus, Service
 
     service = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc2").one()
     # simulate a vanished container: point the record at a non-existent id
@@ -689,8 +312,6 @@ def test_reconciler_idles_then_wakes(test_db, test_docker, test_settings):
     """The reconciler scales an idle service to zero, then wakes it once it sees traffic again."""
     from datetime import datetime, timezone
 
-    from triton_serve.database.model import DesiredState, RuntimeStatus
-
     svc = test_db.query(Service).filter(Service.service_name == "trt-srv_test_svc4").one()  # timeout=5s
     svc.desired_state = DesiredState.AVAILABLE
     test_db.commit()
@@ -703,20 +324,21 @@ def test_reconciler_idles_then_wakes(test_db, test_docker, test_settings):
     test_db.commit()
     update_service_status.apply()  # target back to 1 -> start/recreate
     test_db.refresh(svc)
-    assert svc.runtime_status in (RuntimeStatus.WARMING, RuntimeStatus.READY)
+    assert svc.runtime_status in (RuntimeStatus.WARMING, RuntimeStatus.READY, RuntimeStatus.IDLE)
 
 
-@pytest.mark.order(after="test_update_service_recreate")
-def test_delete_services(test_client, test_docker, test_db):
-    # get all services
-    services = test_db.query(Service).all()
+@pytest.mark.order(after="test_reconciler_idles_then_wakes")
+def test_delete_is_db_only(test_client, test_db):
+    """Delete is DB-only: it tombstones the record and drops it from listings; the reconciler
+    tears down the container out of band."""
+    services = test_db.query(Service).filter(Service.deleted_at.is_(None)).all()
     for service in services:
-        query_params = {"delete_container": True}
-        response = test_client.delete(f"/services/{service.service_id}", params=query_params)
-        data = response.json()
-        assert response.status_code == 202
-        assert data["service_id"] == service.service_id
-        assert data["deleted_at"] is not None
-        # check if container has been deleted
-        with pytest.raises(NotFound):
-            test_docker.containers.get(service.container_id)
+        service_id = service.service_id
+        response = test_client.delete(f"/services/{service_id}")
+        assert response.status_code == 204
+        test_db.refresh(service)
+        assert service.deleted_at is not None
+        assert service.desired_state == DesiredState.RETIRED
+
+    listing = test_client.get("/services").json()
+    assert listing == []

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -31,6 +31,27 @@ def test_retry_columns_exist(test_db):
     assert {"restart_attempts", "last_attempt_at"} <= cols
 
 
+def test_lifecycle_enums_and_columns(test_db):
+    from sqlalchemy import inspect
+
+    from triton_serve.database.model import DesiredState, RuntimeStatus
+
+    assert {s.value for s in DesiredState} == {"available", "suspended", "retired"}
+    assert {s.value for s in RuntimeStatus} == {
+        "ready",
+        "warming",
+        "idle",
+        "recovering",
+        "failed",
+        "suspended",
+        "retired",
+    }
+    cols = {c["name"] for c in inspect(test_db.connection()).get_columns("services")}
+    assert {"desired_state", "runtime_status"} <= cols
+    # expand phase: the old column still exists; it is dropped in Task 6 once nothing reads it
+    assert "container_status" in cols
+
+
 @pytest.mark.order(after="test_auth.py::test_api_key_authorized")
 @pytest.mark.parametrize(
     "name, models, resources, timeout",

--- a/tests/test_traefik_sync.py
+++ b/tests/test_traefik_sync.py
@@ -11,7 +11,6 @@ from triton_serve.database.model import (
     Base,
     KeyType,
     Service,
-    ServiceStatus,
     key_service_association,
     utcnow,
 )
@@ -38,7 +37,6 @@ def service(db_session):
     svc = Service(
         service_name="demo",
         service_image="img",
-        container_status=ServiceStatus.ACTIVE,
         last_active_time=utcnow(),
         priority=0,
     )


### PR DESCRIPTION
Closes #115 (pillars 1 & 2: ephemeral create/delete + read-only GET side).

## What & why

A power-surge reboot left services unreachable for ~17h: a `STOPPED`/vanished-container service `404`'d forever with no recovery path, and a docker-daemon storm blocked every request (the per-request `docker.from_env()` had a 60s timeout). Root cause: `container_status` was one flat enum conflating operator intent, observed reality, and what we tell traefik — so failure modes were missing cells in a matrix that was never written down.

This replaces it with a declarative model that ports cleanly onto a k8s controller / KServe / Azure Container Apps later:

- **`DesiredState`** (`AVAILABLE` / `SUSPENDED` / `RETIRED`) — operator intent.
- **`ObservedFact`** — runtime truth, re-derived each reconciler tick.
- **`RuntimeStatus`** (`READY`/`WARMING`/`IDLE`/`RECOVERING`/`FAILED`/`SUSPENDED`/`RETIRED`) — a persisted projection.
- A **pure, total `decide()`** function (`api/services/reconcile.py`) encodes the whole reconciliation matrix (`test_decide_is_total` sweeps every cell). Thin `observe()` / `execute()` wrap Docker I/O.
- The **reconciler loop** owns *all* Docker mutation; the **request path is read-only** w.r.t. the runtime. `/status` reads persisted status only (`READY`→200, not-ready→`503 Retry-After`, never 2XX), killing the old `202`→forwardAuth→502 bug.
- **Create/update/delete are fully declarative** — no Docker in any request handler. Create returns `201` before the container exists; a bad image surfaces asynchronously as `FAILED`. Chosen for the ACA/KServe future (API = desired-state store, reconciler = swappable backend adapter).
- **Crash budget**: bounded retries with exponential backoff → terminal `FAILED`, reset via `POST /services/{id}/retry`.

The 2026-07-15 outage cell (`AVAILABLE·ABSENT·target=1 → recreate`) is now an ordinary matrix row.

## Schema

Expand/contract: an additive migration adds the new columns, a contract migration drops `container_status`/`ServiceStatus`.

## Verification

`make test PROFILE=cpu` → **122 passed, 1 skipped, 0 failed**. Went through a whole-branch review; fixes for the 1 Critical + 3 Important findings are included (crash-budget-on-failure, synchronous traefik teardown on delete, backoff gating, migration downgrade).

## Deferred follow-ups

- Circuit breaker on the reconciler's Docker client (short timeout is in place).
- Update-driven container "revisions" (declarative rollout of config changes) — maps to ACA revisions.
- Pillar 3 of #115 (client-side CLI image packaging) — separate plan.

## Breaking API changes

- Service and allocation responses replace `container_status` (enum `ServiceStatus`) with **`runtime_status`** (`RuntimeStatus`) plus **`desired_state`** (`DesiredState`).
- `GET /services` filter param `container_statuses` → **`runtime_statuses`**.
- `PUT /services/{id}` no longer accepts the `recreate` flag (updates are declarative; config lands on the next (re)create).

Any external CLI/UI reading these fields must update. There is no compatibility shim.

## Second review round

A second whole-branch review found the crash budget was not actually terminal (elapsed-time reset revived FAILED), boot grace never expired for stuck-unhealthy containers, and single-flight was dropped. All fixed in `f0ef25a`; `make test PROFILE=cpu` → **127 passed, 1 skipped**.